### PR TITLE
Support including the 6to5 polyfill when requested.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -3,7 +3,11 @@
 
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
-var app = new EmberAddon();
+var app = new EmberAddon({
+  babel: {
+    includePolyfill: true
+  }
+});
 
 // Use `app.import` to add additional libraries to the generated
 // output files.

--- a/README.md
+++ b/README.md
@@ -22,12 +22,21 @@ found [here](https://babeljs.io/docs/usage/options/). Example:
 // Brocfile.js
 
 var app = new EmberApp({
-	'babel': {
-		// disable comments
-		comments: false
-	}
+  babel: {
+    // disable comments
+    comments: false
+  }
 });
 ```
+
+### Polyfill
+
+Babel comes with a polyfill that includes a custom [regenerator runtime](https://github.com/facebook/regenerator/blob/master/runtime.js)
+and [core.js](https://github.com/zloirock/core-js). Many transformations will work without it, but for full support you
+must include the polyfill in your app. The [Babel feature tour](https://babeljs.io/docs/tour/) includes a note for
+features that require the polyfill to work.
+
+To include it in your app, pass `includePolyfill: true` in your `babel` options.
 
 ### About Modules
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
   },
 
   importPolyfill: function(app) {
-    app.import('vendor/browser-polyfill.js');
+    app.import('vendor/browser-polyfill.js', { prepend: true });
   },
 
   treeFor: function(name) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   "dependencies": {
     "broccoli-babel-transpiler": "^5.0.0",
     "broccoli-filter": "^0.1.10",
-    "ember-cli-version-checker": "^1.0.2"
+    "clone": "^1.0.2",
+    "ember-cli-version-checker": "^1.0.2",
+    "resolve": "^1.1.2"
   },
   "devDependencies": {
     "bower": "^1.4.1",

--- a/tests/acceptance/simple-test.js
+++ b/tests/acceptance/simple-test.js
@@ -19,5 +19,7 @@ test('value of input', function(assert) {
 
   andThen(() => {
     assert.equal('Test Value', find('#test-input').val());
+    assert.equal('one', find('#first-value').text());
+    assert.equal('two', find('#last-value').text());
   });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -2,5 +2,8 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   // Just a very roundabout way of using some ES6 features
-  value: ((test = 'Test') => `${test} ${'Value'}`)() // jshint ignore:line
+  value: ((test = 'Test') => `${test} ${'Value'}`)(), // jshint ignore:line
+
+  // Test a generator (needs the regenerator runtime) and some ES6 constructs (requires the corejs polyfill)
+  values: Array.from({ *[Symbol.iterator]() { yield 'one'; yield 'two'; } }) // jshint ignore:line
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,4 +2,7 @@
 
 {{input id="test-input" value=value}}
 
+<div id="first-value">{{values.firstObject}}</div>
+<div id="last-value">{{values.lastObject}}</div>
+
 {{outlet}}


### PR DESCRIPTION
6to5 relies on a custom polyfill for [some features](https://6to5.org/docs/caveats/) (generators, symbols for iteration, etc). This PR adds an `includePolyfill` flag to incorporate that file into the build.

Since the polyfill patches built-in objects, I left the inclusion off by default, but I could also see an argument for making the behavior opt-out instead.