### PR TITLE
Limit babelification to .es6 extensions only - do not merge

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -3,7 +3,11 @@
 
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
-var app = new EmberAddon();
+var app = new EmberAddon({
+  babel: {
+    validExtensions:['js','es6'] // Support both .es6 and .js extensions for babel
+  }
+});
 
 // Use `app.import` to add additional libraries to the generated
 // output files.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var checker   = require('ember-cli-version-checker');
-
+var clone     = require('clone');
 module.exports = {
   name: 'ember-cli-babel',
 
@@ -13,7 +13,15 @@ module.exports = {
       name: 'ember-cli-babel',
       ext: 'js',
       toTree: function(tree) {
-        return require('broccoli-babel-transpiler')(tree, getOptions(addon));
+        var options = getOptions(addon);
+        var transpiler = require('broccoli-babel-transpiler');
+        var validExtensions = options.validExtensions || ['js'];
+        if (options.validExtensions) {
+          transpiler.extensions = validExtensions;
+          delete options.validExtensions;
+        }
+
+        return transpiler(tree, options);
       }
     };
 
@@ -50,5 +58,5 @@ function getOptions(addonContext) {
   // Ember-CLI inserts its own 'use strict' directive
   options.blacklist.push('useStrict');
 
-  return options;
+  return clone(options);
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "broccoli-babel-transpiler": "^4.0.0",
     "broccoli-filter": "^0.1.10",
+    "clone": "^0.2.0",
     "ember-cli-version-checker": "^1.0.2"
   },
   "devDependencies": {

--- a/tests/acceptance/simple-test.js
+++ b/tests/acceptance/simple-test.js
@@ -21,3 +21,11 @@ test('value of input', function(assert) {
     assert.equal('Test Value', find('#test-input').val());
   });
 });
+
+test('value of input on other(es6) route', function(assert) {
+  visit('/other');
+
+  andThen(() => {
+    assert.equal('Other Value', find('#other-input').val());
+  });
+});

--- a/tests/dummy/app/controllers/other.js
+++ b/tests/dummy/app/controllers/other.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  // Just a very roundabout way of using some ES6 features
+  value: ((test = 'Other') => `${test} ${'Value'}`)() // jshint ignore:line
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,6 +6,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+    this.route('other');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/other.hbs
+++ b/tests/dummy/app/templates/other.hbs
@@ -1,0 +1,1 @@
+{{input id="other-input" value=value}}


### PR DESCRIPTION
I have a cleaner fix to this issue at https://github.com/babel/broccoli-babel-transpiler/pull/15

We have a very large project with limited (currently) use of es6 features beyond modules.

The performance delta is documented in: https://github.com/ember-cli/ember-cli/issues/3637#issuecomment-85745165

I'm happy to make the change (configurable extensions to babelize with .js as the default) in either project.

would like feedback as to preference for this addon or broccoli-babel-transpiler