### PR TITLE
Possibility to add babel plugins via registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,35 @@ features that require the polyfill to work.
 
 To include it in your app, pass `includePolyfill: true` in your `babel` options.
 
+### Adding custom babel plugins
+
+Custom [babel plugins](https://babeljs.io/docs/usage/plugins/) can be added to
+the transformation pipeline via Ember-CLI addons. The specific transformations
+needs to be added to the registry using `babel-plugin` as type:
+
+```js
+// my-babel-transformation-addon/index.js
+module.exports = {
+  name: 'my-babel-transformation-addon',
+
+  setupPreprocessorRegistry: function(type, registry) {
+    var MyBabelTransformation = require('./my-babel-transformation');
+
+    registry.add('babel-plugin', {
+      name: 'my-babel-transformation',
+      plugin: MyBabelTransformation
+    });
+  }
+}
+
+// my-babel-transformation-addon/my-babel-transformation.js
+module.exports = function(babel) {
+  return new babel.Transformer('my-babel-transformation', {
+    // see http://babeljs.io/docs/usage/plugins/manipulation/ for examples
+  });
+}
+```
+
 ### About Modules
 
 Ember-CLI uses its own ES6 module transpiler for the custom Ember resolver that it uses. Because of that,

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ module.exports = {
   setupPreprocessorRegistry: function(type, registry) {
     var addon = this;
 
+    if (type === 'parent') {
+      this.parentRegistry = registry;
+    }
+
     registry.add('js', {
       name: 'ember-cli-babel',
       ext: 'js',
@@ -89,6 +93,15 @@ function getBabelOptions(addonContext) {
       options.blacklist.push('es6.modules');
     }
   }
+
+  // get all babel-plugins in the registry
+  var pluginWrappers = addonContext.parentRegistry.load('babel-plugin');
+  var babelPlugins = pluginWrappers.map(function(wrapper) {
+    return wrapper.plugin;
+  });
+
+  // add babel-plugins from the registry to the options.plugins
+  options.plugins = (options.plugins || []).concat(babelPlugins);
 
   // Ember-CLI inserts its own 'use strict' directive
   options.blacklist.push('useStrict');

--- a/index.js
+++ b/index.js
@@ -96,7 +96,24 @@ function getBabelOptions(addonContext) {
 
   // get all babel-plugins in the registry
   var pluginWrappers = addonContext.parentRegistry.load('babel-plugin');
-  var babelPlugins = pluginWrappers.map(function(wrapper) {
+
+  // currently only a specific set of babel-plugin's is added to the pipeline:
+  // the reason is that if the ember-cli addon "ember-cli-my-addon" needs
+  // "babel-plugin-1" and an app uses the "ember-cli-my-addon" but doesn't
+  // list the "babel-plugin-1" in its package.json, the "ember-cli-my-addon" is
+  // not correctly pre-processed for the app, since "babel-plugin-1" is not
+  // available in the build pipeline
+  //
+  // as a current workaround for this, the allowed plugins are whitelisted
+  // here, until a general solution exists. see
+  // https://github.com/babel/ember-cli-babel/pull/42 for further context.
+  var allowedBabelPlugins = ['ember-cli-htmlbars-inline-precompile'];
+  var babelPlugins = pluginWrappers.filter(function(wrapper) {
+    // only allow whitelisted plugins
+    return allowedBabelPlugins.indexOf(wrapper.name) !== -1;
+  });
+
+  babelPlugins = babelPlugins.map(function(wrapper) {
     return wrapper.plugin;
   });
 

--- a/lib/.jshintrc
+++ b/lib/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "node": true,
+  "browser": false
+}

--- a/lib/answer-to-the-universe/index.js
+++ b/lib/answer-to-the-universe/index.js
@@ -1,0 +1,16 @@
+module.exports = {
+  name: 'answer-to-the-universe',
+
+  isDevelopingAddon: function() {
+    return true;
+  },
+
+  setupPreprocessorRegistry: function(type, registry) {
+    var ProvideAnswerTransformation = require('./provide-answer-transformation');
+
+    registry.add('babel-plugin', {
+      name: 'answer-to-the-universe',
+      plugin: ProvideAnswerTransformation
+    });
+  }
+};

--- a/lib/answer-to-the-universe/package.json
+++ b/lib/answer-to-the-universe/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "answer-to-the-universe",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/lib/answer-to-the-universe/provide-answer-transformation.js
+++ b/lib/answer-to-the-universe/provide-answer-transformation.js
@@ -1,0 +1,11 @@
+module.exports = function(babel) {
+  var t = babel.types;
+
+  return new babel.Transformer('answer-to-the-universe', {
+    Literal: function(node) {
+      if (node.value === 'THE-answer') {
+        return t.literal(42);
+      }
+    }
+  });
+};

--- a/lib/ember-cli-htmlbars-inline-precompile-mock/index.js
+++ b/lib/ember-cli-htmlbars-inline-precompile-mock/index.js
@@ -1,0 +1,16 @@
+module.exports = {
+  name: 'ember-cli-htmlbars-inline-precompile',
+
+  isDevelopingAddon: function() {
+    return true;
+  },
+
+  setupPreprocessorRegistry: function(type, registry) {
+    var PrecompileTransformation = require('./precompile-transformation');
+
+    registry.add('babel-plugin', {
+      name: 'ember-cli-htmlbars-inline-precompile',
+      plugin: PrecompileTransformation
+    });
+  }
+};

--- a/lib/ember-cli-htmlbars-inline-precompile-mock/package.json
+++ b/lib/ember-cli-htmlbars-inline-precompile-mock/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ember-cli-htmlbars-inline-precompile",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/lib/ember-cli-htmlbars-inline-precompile-mock/precompile-transformation.js
+++ b/lib/ember-cli-htmlbars-inline-precompile-mock/precompile-transformation.js
@@ -1,0 +1,11 @@
+module.exports = function(babel) {
+  var t = babel.types;
+
+  return new babel.Transformer('ember-cli-htmlbars-inline-precompile', {
+    Literal: function(node) {
+      if (node.value === 'my template') {
+        return t.literal("precompiled");
+      }
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "jshint": "^2.6.3"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "paths": [
+      "lib/answer-to-the-universe"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "paths": [
-      "lib/answer-to-the-universe"
+      "lib/answer-to-the-universe",
+      "lib/ember-cli-htmlbars-inline-precompile-mock"
     ]
   }
 }

--- a/tests/acceptance/simple-test.js
+++ b/tests/acceptance/simple-test.js
@@ -23,3 +23,10 @@ test('value of input', function(assert) {
     assert.equal('two', find('#last-value').text());
   });
 });
+
+test('babel-plugin is looked up from the registry', function(assert) {
+  // the string below is replaced by a babel transformation, which is
+  // registered as 'babel-plugin' within the 'answer-to-the-universe' in repo
+  // addon
+  assert.equal('THE-answer', 42);
+});

--- a/tests/acceptance/simple-test.js
+++ b/tests/acceptance/simple-test.js
@@ -24,9 +24,17 @@ test('value of input', function(assert) {
   });
 });
 
+test('ember-cli-htmlbars-inline-precompile is looked up from the registry', function(assert) {
+  // the ember-cli-htmlbars-inline-precompile-mock in-repo-addon registers a
+  // whitelisted plugin, which replaces a "my template" string with
+  // "precompiled"
+  assert.equal("my template", "precompiled");
+});
+
 test('babel-plugin is looked up from the registry', function(assert) {
-  // the string below is replaced by a babel transformation, which is
-  // registered as 'babel-plugin' within the 'answer-to-the-universe' in repo
-  // addon
-  assert.equal('THE-answer', 42);
+  // Altough there is a babel-plugin registered which would replace the string
+  // below with 42, the string is not replaced, since currently only specific
+  // babel-plugins are whitelisted. See
+  // https://github.com/babel/ember-cli-babel/pull/42 for context.
+  assert.notEqual('THE-answer', 42);
 });


### PR DESCRIPTION
This allows Ember-CLI addons to add custom babel transformations to the
ember-cli-babel pipeline by registering a plugin using the
`babel-plugin` type:

``` javascript
// my-addon/index.js
module.exports = {
  name: 'my-addon-using-babel-transformer',

  setupPreprocessorRegistry: function(type, registry) {
    var BabelTransformerPlugin = require('./babel-transformer-plugin');

    registry.add('babel-plugin', {
      name: 'my-addon-using-babel-transformer',
      plugin: BabelTransformerPlugin
    });
  }
}

// my-addon/babel-transformer-plugin.js
module.exports = function(babel) {
  var t = babel.types;
  return new babel.Transformer('troll-transformer', {
    Literal: function(node) {
      if (node.value === true) {
        return t.literal(false);
      } else if (node.value === false) {
        return t.literal(true);
      }
    }
  });
}
```

---

I will add a section to the README if this is accepted.

This addresses pangratz/ember-cli-htmlbars-inline-precompile#7
