### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/babel/ember-cli-babel",
   "dependencies": {
-    "broccoli-babel-transpiler": "babel/broccoli-babel-transpiler#broccoli-peristent-filter",
+    "broccoli-babel-transpiler": "babel/broccoli-babel-transpiler#broccoli-persistent-filter",
     "broccoli-funnel": "^0.2.3",
     "clone": "^1.0.2",
     "ember-cli-version-checker": "^1.0.2",


### PR DESCRIPTION
```shell
npm ERR! git rev-list -n1 broccoli-peristent-filter: fatal: ambiguous argument 'broccoli-peristent-filter': unknown revision or path not in the working tree.
npm ERR! git rev-list -n1 broccoli-peristent-filter: Use '--' to separate paths from revisions, like this:
npm ERR! git rev-list -n1 broccoli-peristent-filter: 'git <command> [<revision>...] -- [<file>...]'
npm ERR! git rev-list -n1 broccoli-peristent-filter: 
npm ERR! git rev-list -n1 broccoli-peristent-filter: fatal: ambiguous argument 'broccoli-peristent-filter': unknown revision or path not in the working tree.
npm ERR! git rev-list -n1 broccoli-peristent-filter: Use '--' to separate paths from revisions, like this:
npm ERR! git rev-list -n1 broccoli-peristent-filter: 'git <command> [<revision>...] -- [<file>...]'
npm ERR! git rev-list -n1 broccoli-peristent-filter: 
npm ERR! git rev-list -n1 broccoli-peristent-filter: fatal: ambiguous argument 'broccoli-peristent-filter': unknown revision or path not in the working tree.
npm ERR! git rev-list -n1 broccoli-peristent-filter: Use '--' to separate paths from revisions, like this:
npm ERR! git rev-list -n1 broccoli-peristent-filter: 'git <command> [<revision>...] -- [<file>...]'
npm ERR! git rev-list -n1 broccoli-peristent-filter: 
Command failed: git rev-list -n1 broccoli-peristent-filter
fatal: ambiguous argument 'broccoli-peristent-filter': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

Error: Command failed: git rev-list -n1 broccoli-peristent-filter
fatal: ambiguous argument 'broccoli-peristent-filter': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

    at ChildProcess.exithandler (child_process.js:744:12)
    at ChildProcess.emit (events.js:110:17)
    at maybeClose (child_process.js:1008:16)
    at Socket.<anonymous> (child_process.js:1176:11)
    at Socket.emit (events.js:107:17)
    at Pipe.close (net.js:476:12)
```