### PR TITLE
Fix ref to persistent filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/babel/ember-cli-babel",
   "dependencies": {
-    "broccoli-babel-transpiler": "babel/broccoli-babel-transpiler#broccoli-peristent-filter",
+    "broccoli-babel-transpiler": "babel/broccoli-babel-transpiler#broccoli-persistent-filter",
     "broccoli-funnel": "^0.2.3",
     "clone": "^1.0.2",
     "ember-cli-version-checker": "^1.0.2",


### PR DESCRIPTION
This is throwing weird git ref stuff on installs now. Likely due to the misspelling. For folks who might be locked in, it could be good to actually create a misspelled branch, so it just starts working....