### PR TITLE
Bump to version 5.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-babel",
-  "version": "5.1.3",
+  "version": "5.1.5",
   "main": "index.js",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
@stefanpenner, what happened with 5.1.4? There seems to be a published 5.1.4, but the last revision in the repo was 5.1.3. Is it OK to merge this and publish a new revision or will that conflict with changes in Ember CLI?