### PR TITLE
Update README to have ES6 feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,37 @@ features that require the polyfill to work.
 
 To include it in your app, pass `includePolyfill: true` in your `babel` options.
 
+### Features
+
+Out of the box without a polyfill the following ES6 features are enabled:
+
+| Feature  | Supported |
+| ------------- | ------------- |
+| Arrows and Lexical This | YES |
+| Classes | YES |
+| Enhanced Object Literals | YES |
+| Template Strings | YES |
+| Destructuring | YES |
+| Default + Rest + Spread | YES |
+| Let + Const | YES |
+| Iterators + For..Of | NO |
+| Generators | NO |
+| Comprehensions | YES |
+| Unicode | YES |
+| Modules | YES |
+| Module Loaders | NO |
+| Map + Set + WeakMap + WeakSet | NO |
+| Proxies | NO |
+| Symbols | NO |
+| Subclassable Built-ins | PARTIAL |
+| Math + Number + String + Object APIs | NO |
+| Binary and Octal Literals | PARTIAL |
+| Promises | NO |
+| Reflect API | NO |
+| Tail Calls | PARTIAL |
+
+See the [Babel docs](babeljs.io/docs/learn-es2015) for more details
+
 ### About Modules
 
 Ember-CLI uses its own ES6 module transpiler for the custom Ember resolver that it uses. Because of that,


### PR DESCRIPTION
I needed to communicate to my team what ES6 features they could use without polyfills enabled and I put together the following list from the [Babel Docs](http://babeljs.io/docs/learn-es2015/)

@rwjblue suggested I add it to the README here