### PR TITLE
Fix app options

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,10 @@ module.exports = {
 };
 
 function getAddonOptions(addonContext) {
-  var baseOptions = (addonContext.parent && addonContext.parent.options) || (addonContext.app && addonContext.app.options);
+  var parentOptions = addonContext.parent && addonContext.parent.options;
+  var appOptions = addonContext.app && addonContext.app.options;
+  var emberAppOptions = addonContext.app && addonContext.app.app && addonContext.app.app.options;
+  var baseOptions = parentOptions || appOptions || emberAppOptions;
   return baseOptions && baseOptions.babel || {};
 }
 


### PR DESCRIPTION
When you define a `babel` section in `ember-cli-build.js` in order to pass options to babel transpiller, the addon does not find it because `addonContext.app` is not really an `EmberApp` instance. 
`EmberApp` instance is stored at `addonContext.app.app` and it has all the options.