### PR TITLE
Add fastboot check

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ module.exports = {
 
   shouldIncludePolyfill: function() {
     var options = getAddonOptions(this);
-    return options.includePolyfill === true;
+    var isNotFastboot = !process.env.EMBER_CLI_FASTBOOT;
+    return options.includePolyfill === true && isNotFastboot;
   },
 
   importPolyfill: function(app) {


### PR DESCRIPTION
This PR disabling `app.import` that is not allowed in ember fastboot. Maybe there are another way to fix this then I am ready to implement it, just let me know.
