### PR TITLE
Pass console object in to broccoli-babel-transpiler.

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,21 @@ function getAddonOptions(addonContext) {
 function getBabelOptions(addonContext) {
   var options = clone(getAddonOptions(addonContext));
 
+  // pass a console object that wraps the addon's `UI` object
+  options.console = {
+    log: function(message) {
+      addonContext.ui.writeInfoLine(message);
+    },
+
+    warn: function(message) {
+      addonContext.ui.writeWarnLine(message);
+    },
+
+    error: function(message) {
+      addonContext.ui.writeError(message, 'ERROR');
+    }
+  };
+
   // Ensure modules aren't compiled unless explicitly set to compile
   options.blacklist = options.blacklist || ['es6.modules'];
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "broccoli-babel-transpiler": "^5.4.5",
+    "broccoli-babel-transpiler": "^5.6.0",
     "broccoli-funnel": "^1.0.0",
     "clone": "^1.0.2",
     "ember-cli-version-checker": "^1.0.2",


### PR DESCRIPTION
This will be used by broccoli-babel-transpiler to log warnings/deprecations to the console when a given plugin does not provide the correct caching information.

This will be used by https://github.com/babel/broccoli-babel-transpiler/pull/89.