### PR TITLE
Fix issue with app.import being undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,9 @@ module.exports = {
   },
 
   importPolyfill: function(app) {
-    if (app.import) {
+    if (this.import) {  // support for ember-cli >= 2.7
+      this.import('vendor/browser-polyfill.js', { prepend: true });
+    } else { // support ember-cli < 2.7
       app.import('vendor/browser-polyfill.js', { prepend: true });
     }
   },

--- a/index.js
+++ b/index.js
@@ -31,7 +31,9 @@ module.exports = {
   },
 
   importPolyfill: function(app) {
-    app.import('vendor/browser-polyfill.js', { prepend: true });
+    if (app.import) {
+      app.import('vendor/browser-polyfill.js', { prepend: true });
+    }
   },
 
   treeFor: function(name) {

--- a/index.js
+++ b/index.js
@@ -33,14 +33,10 @@ module.exports = {
   importPolyfill: function(app) {
     if (this.import) {  // support for ember-cli >= 2.7
       this.import('vendor/browser-polyfill.js', { prepend: true });
-    } else { // support ember-cli < 2.7
-      while (app.app) {
-        app = app.app
-      }
-
-      if (app.import) {
-        app.import('vendor/browser-polyfill.js', { prepend: true });
-      }
+    } else if (app.import) { // support ember-cli < 2.7
+      app.import('vendor/browser-polyfill.js', { prepend: true });
+    } else {
+      console.warn('Please run: ember install ember-cli-import-polyfill')
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,13 @@ module.exports = {
     if (this.import) {  // support for ember-cli >= 2.7
       this.import('vendor/browser-polyfill.js', { prepend: true });
     } else { // support ember-cli < 2.7
-      app.import('vendor/browser-polyfill.js', { prepend: true });
+      while (app.app) {
+        app = app.app
+      }
+
+      if (app.import) {
+        app.import('vendor/browser-polyfill.js', { prepend: true });
+      }
     }
   },
 


### PR DESCRIPTION
This fixes the following error I'm coming across in an application that consumers the addon [ember-prop-types](https://github.com/ciena-blueplanet/ember-prop-types) which enables the *includePolyfill* flag [here](https://github.com/ciena-blueplanet/ember-prop-types/blob/master/index.js#L15).
```
app.import is not a function
TypeError: app.import is not a function
  at Class.module.exports.importPolyfill (/Repositories/my-app/node_modules/ember-cli-babel/index.js:35:15)
  at Class.module.exports.included (/Repositories/my-app/node_modules/ember-cli-babel/index.js:60:12)
  at /Repositories/my-app/node_modules/ember-cli/lib/models/addon.js:244:32
  at Array.map (native)
  at Class.eachAddonInvoke (/Repositories/my-app/node_modules/ember-cli/lib/models/addon.js:242:22)
  at Class.Addon.included (/Repositories/my-app/node_modules/ember-cli/lib/models/addon.js:349:8)
  at EmberApp.<anonymous> (/Repositories/my-app/node_modules/ember-cli/lib/broccoli/ember-app.js:433:15)
  at Array.filter (native)
  at EmberApp._notifyAddonIncluded (/Repositories/my-app/node_modules/ember-cli/lib/broccoli/ember-app.js:428:45)
  at new EmberApp (/Repositories/my-app/node_modules/ember-cli/lib/broccoli/ember-app.js:109:8)
  at module.exports.defaults (/Repositories/my-app/ember-cli-build.js:6:13)
  at Class.module.exports.Task.extend.setupBroccoliBuilder (/Repositories/my-app/node_modules/ember-cli/lib/models/builder.js:55:19)
  at Class.module.exports.Task.extend.init (/Repositories/my-app/node_modules/ember-cli/lib/models/builder.js:89:10)
  at new Class (/Repositories/my-app/node_modules/ember-cli/node_modules/core-object/core-object.js:18:12)
  at Class.module.exports.Task.extend.run (/Repositories/my-app/node_modules/ember-cli/lib/tasks/build.js:15:19)
  at Class.<anonymous> (/Repositories/my-app/node_modules/ember-cli/lib/commands/test.js:162:27)
  at lib$rsvp$$internal$$tryCatch (/Repositories/my-app/node_modules/rsvp/dist/rsvp.js:1036:16)
  at lib$rsvp$$internal$$invokeCallback (/Repositories/my-app/node_modules/rsvp/dist/rsvp.js:1048:17)
  at /Repositories/my-app/node_modules/rsvp/dist/rsvp.js:331:11
  at lib$rsvp$asap$$flush (/Repositories/my-app/node_modules/rsvp/dist/rsvp.js:1198:9)
  at doNTCallback0 (node.js:428:9)
  at process._tickCallback (node.js:357:13)
```