### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ and [core.js](https://github.com/zloirock/core-js). Many transformations will wo
 must include the polyfill in your app. The [Babel feature tour](https://babeljs.io/docs/tour/) includes a note for
 features that require the polyfill to work.
 
-To include it in your app, pass `includePolyfill: true` in your `babel` options.
+To include it in your app, pass `includePolyfill: true` in your `ember-cli-babel` options.
 
 ### Features
 


### PR DESCRIPTION
* `includePolyfill` is no longer part of `babel` options, now is part of `ember-cli-babel` options.
* A deprecation is shown if it was used in `babel` options
  https://github.com/babel/ember-cli-babel/blob/2b1c8cf06937d0f37bfb378cbf435c721848f837/index.js#L47