### PR TITLE
Expose `postTransformPlugins` to be positioned after `preset-env` plugins.

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,11 +154,15 @@ module.exports = {
     let shouldCompileModules = this._shouldCompileModules();
 
     let userPlugins = [].concat(options.plugins, babel6Options.plugins).filter(Boolean);
+    let userPostTransformPlugins = [].concat(options.postTransformPlugins, babel6Options.postTransformPlugins).filter(Boolean);
+
+    delete options.postTransformPlugins;
 
     options.plugins = [].concat(
       userPlugins,
       shouldCompileModules && this._getModulesPlugin(),
-      this._getPresetEnvPlugins()
+      this._getPresetEnvPlugins(),
+      userPostTransformPlugins
     ).filter(Boolean);
     options.moduleIds = true;
 

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -336,6 +336,25 @@ describe('ember-cli-babel', function() {
       expect(result.plugins).to.include(plugin);
     });
 
+    it('includes postTransformPlugins after preset-env plugins', function() {
+      let plugin = {};
+      let pluginAfter = {};
+      this.addon.parent = {
+        options: {
+          babel: {
+            plugins: [ plugin ],
+            postTransformPlugins: [ pluginAfter ]
+          },
+        },
+      };
+
+      let result = this.addon._getBabelOptions();
+
+      expect(result.plugins).to.include(plugin);
+      expect(result.plugins.slice(-1)).to.deep.equal([pluginAfter]);
+      expect(result.postTransformPlugins).to.be.undefined;
+    });
+
     it('includes user plugins in parent.options.babel6.plugins', function() {
       let plugin = {};
       this.addon.parent = {


### PR DESCRIPTION
Fixes #119.