### PR TITLE
Properly forward the browsers targets to ember-preset-env

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ module.exports = {
     let browsers = targets && targets.browsers;
     let presetOptions = Object.assign({}, options, {
       modules: false,
-      browsers
+      targets: { browsers },
     });
 
     let presetEnvPlugins = this._presetEnv(null, presetOptions).plugins;


### PR DESCRIPTION
Currently they are completely ignored.