### PR TITLE
Only pass provided options to babel-preset-env.

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ module.exports = {
     let providedConfig = this._getProvidedBabelConfig();
     let shouldCompileModules = this._shouldCompileModules();
 
-    let options = providedConfig.options;
+    let options = {};
     let userPlugins = providedConfig.plugins;
     let userPostTransformPlugins = providedConfig.postTransformPlugins;
 

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -310,6 +310,18 @@ describe('ember-cli-babel', function() {
   describe('_getBabelOptions', function() {
     this.timeout(20000);
 
+    it('does not include all provided options', function() {
+      let babelOptions = { blah: true };
+      this.addon.parent = {
+        options: {
+          babel: babelOptions,
+        },
+      };
+
+      let result = this.addon._getBabelOptions();
+      expect(result.blah).to.be.undefined;
+    });
+
     it('does not mutate addonOptions.babel', function() {
       let babelOptions = { blah: true };
       this.addon.parent = {


### PR DESCRIPTION
Thanks to @kanongil for pointing out the issue here.