### PR TITLE
Add basic sanity test to confirm babel-preset-env is working.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "ember-load-initializers": "0.5.1",
     "ember-resolver": "^2.1.0",
     "loader.js": "4.0.11",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "resolve": "^1.3.2"
   },
   "engines": {
     "node": "^4.5 || 6.* || 7.*"


### PR DESCRIPTION
Confirms that a specific plugin is or is not used based on the specified targets.