### PR TITLE
Fix clobbering behavior with babel vs babel6 config.

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ module.exports = {
     }
 
     let addonOptions = this._getAddonOptions();
-    let options = clone(addonOptions.babel || {});
+    let babelOptions = clone(addonOptions.babel || {});
 
     // used only to support using ember-cli-babel@6 at the
     // top level (app or addon during development) on ember-cli
@@ -142,24 +142,22 @@ module.exports = {
     // in older ember-cli versions)
     let babel6Options = clone(addonOptions.babel6 || {});
 
+
+    let options;
     // options.modules is set only for things assuming babel@5 usage
-    if (options.modules) {
+    if (babelOptions.modules) {
       // using babel@5 configuration with babel@6
       // without overriding here we would trigger
       // an error
-      options = {
-        plugins: [].concat(
-          babel6Options.plugins,
-          options.plugins
-        ).filter(Boolean)
-      };
+      options = Object.assign({}, babel6Options);
+    } else {
+      // shallow merge both babelOptions and babel6Options
+      // (plugins/postTransformPlugins are handled separately)
+      options = Object.assign({}, babelOptions, babel6Options);
     }
 
-    let plugins = [].concat(options.plugins, babel6Options.plugins).filter(Boolean);
-    let postTransformPlugins = [].concat(options.postTransformPlugins, babel6Options.postTransformPlugins).filter(Boolean);
-
-    delete options.plugins;
-    delete options.postTransformPlugins;
+    let plugins = [].concat(babelOptions.plugins, babel6Options.plugins).filter(Boolean);
+    let postTransformPlugins = [].concat(babelOptions.postTransformPlugins, babel6Options.postTransformPlugins).filter(Boolean);
 
     this._cachedProvidedConfig =  { options, plugins, postTransformPlugins };
 

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -309,6 +309,33 @@ describe('ember-cli-babel', function() {
     });
   });
 
+  describe('_getProvidedBabelConfig', function() {
+    it('does not mutate addonOptions.babel', function() {
+      let babelOptions = { blah: true };
+      this.addon.parent = {
+        options: {
+          babel: babelOptions,
+        },
+      };
+
+      let result = this.addon._getProvidedBabelConfig();
+      expect(result.options).to.not.equal(babelOptions);
+    });
+
+    it('includes options specified in parent.options.babel6', function() {
+      this.addon.parent = {
+        options: {
+          babel6: {
+            loose: true
+          },
+        },
+      };
+
+      let result = this.addon._getProvidedBabelConfig();
+      expect(result.options.loose).to.be.true;
+    });
+  });
+
   describe('_getBabelOptions', function() {
     this.timeout(20000);
 
@@ -322,18 +349,6 @@ describe('ember-cli-babel', function() {
 
       let result = this.addon._getBabelOptions();
       expect(result.blah).to.be.undefined;
-    });
-
-    it('does not mutate addonOptions.babel', function() {
-      let babelOptions = { blah: true };
-      this.addon.parent = {
-        options: {
-          babel: babelOptions,
-        },
-      };
-
-      let result = this.addon._getBabelOptions();
-      expect(result).to.not.equal(babelOptions);
     });
 
     it('includes user plugins in parent.options.babel.plugins', function() {
@@ -430,11 +445,30 @@ describe('ember-cli-babel', function() {
       return false;
     }
 
-    it('passes options through to preset-env', function() {
+    it('passes options.babel through to preset-env', function() {
       let babelOptions = { loose: true };
       this.addon.parent = {
         options: {
           babel: babelOptions,
+        },
+      };
+
+      let invokingOptions;
+      this.addon._presetEnv = function(context, options) {
+        invokingOptions = options;
+        return { plugins: [] };
+      };
+
+      this.addon._getPresetEnvPlugins();
+
+      expect(invokingOptions.loose).to.be.true;
+    });
+
+    it('passes options.babel6 through to preset-env', function() {
+      let babelOptions = { loose: true };
+      this.addon.parent = {
+        options: {
+          babel6: babelOptions,
         },
       };
 


### PR DESCRIPTION
Simplify processing by keeping `options.babel`, `options.babel6`, and our internal `options` completely separate.