### PR TITLE
Expose a public mechanism to transpile a tree.

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,15 +28,15 @@ module.exports = {
     this._shouldShowBabelDeprecations = !dep.lt('2.11.0-beta.2');
   },
 
-  setupPreprocessorRegistry: function(type, registry) {
-    let addon = this;
+  transpileTree(tree) {
+    return require('broccoli-babel-transpiler')(tree, this._getBabelOptions());
+  },
 
+  setupPreprocessorRegistry: function(type, registry) {
     registry.add('js', {
       name: 'ember-cli-babel',
       ext: 'js',
-      toTree: function(tree) {
-        return require('broccoli-babel-transpiler')(tree, addon._getBabelOptions());
-      }
+      toTree: (tree) => this.transpileTree(tree)
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "ember-cli-version-checker": "^1.2.0"
   },
   "devDependencies": {
+    "broccoli-test-helper": "^1.1.0",
     "chai": "^3.5.0",
+    "co": "^4.6.0",
     "console-ui": "^1.0.2",
     "core-object": "^2.0.6",
     "ember-cli": "^2.6.2",


### PR DESCRIPTION
Addons that depend on ember-cli-babel for their own transpilation, but also need to transpile other libs (from ES6 to whatever the project targets) can now use something like:

```js
let babelAddon = this.addons.find(addon => addon.name === 'ember-cli-babel');
let transpiled = babelAddon.transpileTree(someTreeThatNeedsTranspiling);
```

This avoids having to encode the specific concepts of `project.targets` amongst every addon...