### PR TITLE
Remove debugging console.log statement in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,6 @@ module.exports = {
   _getBabelOptions(config) {
     let addonProvidedConfig = this._getAddonProvidedConfig(config);
     let shouldCompileModules = this._shouldCompileModules(config);
-    console.log(shouldCompileModules, config['ember-cli-babel']);
 
     let options = {};
     let userPlugins = addonProvidedConfig.plugins;


### PR DESCRIPTION
[This commit](https://github.com/babel/ember-cli-babel/commit/117a409c7cc8234fb8b526a4177c638d221d46f9#diff-168726dbe96b3ce427e7fedce31bb0bcR172) added a console.log statement inside the `_getBabelOptions` function. This leads to a lot of log statements when building:

```
❯ npm test
true { compileModules: true }
true { compileModules: true }
true { compileModules: true }
true { compileModules: true }
true { compileModules: true }
true { compileModules: true }
true { compileModules: true }
true { compileModules: true }
true { compileModules: true }
true { compileModules: true }
true { compileModules: true }
true { compileModules: true }
true { compileModules: true }
true { compileModules: true }
cleaning up...
Built project successfully. Stored in ...
```