### PR TITLE
Create a target specific polyfill.

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ module.exports = {
   },
 
   _importPolyfill: function(app) {
-    let polyfillPath = 'vendor/babel-polyfill/polyfill.js';
+    let polyfillPath = 'vendor/ember-cli-babel/polyfill.js';
 
     if (this.import) {  // support for ember-cli >= 2.7
       this.import(polyfillPath, { prepend: true });
@@ -82,18 +82,83 @@ module.exports = {
     }
   },
 
+  _requiredPolyfills() {
+    const parseTargets = require('babel-preset-env/').getTargets;
+    const builtInsList = require('babel-preset-env/data/built-ins');
+    const defaultWebIncludes = require('babel-preset-env/lib/default-includes').defaultWebIncludes;
+    const normalizeOptions = require('babel-preset-env/lib/normalize-options').default;
+
+    let config = this._getAddonOptions();
+    let addonProvidedConfig = this._getAddonProvidedConfig(config);
+    let presetOptions = this._getPresetEnvOptions(addonProvidedConfig);
+    let validatedOptions = normalizeOptions(presetOptions);
+    let targets = parseTargets(validatedOptions.targets);
+
+    let polyfillTargets = Object.assign({}, targets);
+    delete polyfillTargets.uglify;
+
+    let polyfills = Object.keys(builtInsList)
+        .concat(defaultWebIncludes)
+        .filter((item) => {
+          let isDefault = defaultWebIncludes.indexOf(item) >= 0;
+          let notExcluded = validatedOptions.exclude.indexOf(item) === -1;
+
+          if (isDefault) { return notExcluded; }
+
+          let isRequired = this.isPluginRequired(builtInsList[item]);
+
+          return isRequired && notExcluded;
+        })
+        .concat(validatedOptions.include);
+
+    return polyfills;
+  },
+
   treeForVendor: function() {
     if (!this._shouldIncludePolyfill()) { return; }
 
-    const Funnel = require('broccoli-funnel');
+    const MergeTrees = require('broccoli-merge-trees');
     const UnwatchedDir = require('broccoli-source').UnwatchedDir;
+    const CreateFile = require('broccoli-file-creator');
+    const Rollup = require('broccoli-rollup');
+
+
+    let requiredPolyfills = this._requiredPolyfills();
+    let polyFillImports = requiredPolyfills
+        .map(module => `import "./${module}"`)
+        .join('\n');
+    let entryPointContents = `;
+if (global._includedPolyfill) {
+  throw new Error("only one instance of ember-cli-babel can have \`includePolyfill\` set");
+}
+global._includedPolyfill = true;
+${polyFillImports}`;
+
+    let entryPointTree = new CreateFile('index.js', entryPointContents);
 
     // Find babel-core's browser polyfill and use its directory as our vendor tree
-    let polyfillDir = path.dirname(require.resolve('babel-polyfill/dist/polyfill'));
+    let coreJSDir = path.dirname(require.resolve('core-js/package'));
+    let coreJSModulesDir = path.join(coreJSDir, 'modules');
+    let coreJSModulesTree = new UnwatchedDir(coreJSModulesDir);
+    let combinedTree = new MergeTrees([coreJSModulesTree, entryPointTree]);
 
-    return new Funnel(new UnwatchedDir(polyfillDir), {
-      destDir: 'babel-polyfill'
+    const resolve = require('rollup-plugin-node-resolve');
+    const commonjs = require('rollup-plugin-commonjs');
+
+    let outputTree = new Rollup(combinedTree, {
+      rollup: {
+        plugins: [
+          resolve({ main: true }),
+          commonjs()
+        ],
+        format: 'umd',
+        entry: 'index.js',
+        dest: 'ember-cli-babel/polyfill.js',
+        sourceMap: false
+      }
     });
+
+    return outputTree;
   },
 
   included: function(app) {
@@ -105,16 +170,20 @@ module.exports = {
     }
   },
 
-  isPluginRequired(pluginName) {
+  isPluginRequired(plugin) {
     let targets = this._getTargets();
 
     // if no targets are setup, assume that all plugins are required
     if (!targets) { return true; }
 
     const isPluginRequired = require('babel-preset-env').isPluginRequired;
-    const pluginList = require('babel-preset-env/data/plugins');
 
-    return isPluginRequired(targets, pluginList[pluginName]);
+    if (typeof plugin === 'string') {
+      const pluginList = require('babel-preset-env/data/plugins');
+      plugin = pluginList[plugin];
+    }
+
+    return isPluginRequired(targets, plugin);
   },
 
   _getAddonOptions: function() {
@@ -218,7 +287,7 @@ module.exports = {
     return [[DebugMacros, options]];
   },
 
-  _getPresetEnvPlugins(config) {
+  _getPresetEnvOptions(config) {
     let options = config.options;
 
     let targets = this._getTargets();
@@ -228,6 +297,11 @@ module.exports = {
       targets: { browsers },
     });
 
+    return presetOptions;
+  },
+
+  _getPresetEnvPlugins(config) {
+    let presetOptions = this._getPresetEnvOptions(config);
     let presetEnvPlugins = this._presetEnv(null, presetOptions).plugins;
 
     presetEnvPlugins.forEach(function(pluginArray) {

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -12,6 +12,7 @@ const stripIndent = CommonTags.stripIndent;
 const BroccoliTestHelper = require('broccoli-test-helper');
 const createBuilder = BroccoliTestHelper.createBuilder;
 const createTempDir = BroccoliTestHelper.createTempDir;
+const walkSync = require('walk-sync');
 
 let Addon = CoreObject.extend(AddonMixin);
 
@@ -698,6 +699,72 @@ describe('ember-cli-babel', function() {
 
       let pluginRequired = this.addon.isPluginRequired('transform-regenerator');
       expect(pluginRequired).to.be.false;
+    });
+  });
+
+  describe('_requiredPolyfills', function() {
+    const builtInsList = require('babel-preset-env/data/built-ins');
+    const defaultWebIncludes = require('babel-preset-env/lib/default-includes').defaultWebIncludes;
+
+    let allKnownPolyfills = [].concat(
+      Object.keys(builtInsList),
+      defaultWebIncludes
+    );
+
+    beforeEach(function() {
+      this.addon.parent.options = { 'ember-cli-babel': { includePolyfill: true } };
+    });
+
+    it('returns the list of all polyfills for an old platform', function() {
+      this.addon.project.targets = {
+        browsers: ['ie 9']
+      };
+
+      let polyfills = this.addon._requiredPolyfills();
+
+      // ie 9 requires all the polyfills :P
+      expect(polyfills).to.deep.equal(allKnownPolyfills);
+    });
+
+    it('returns a subset of the polyfills for a recent platform', function() {
+      this.addon.project.targets = {
+        browsers: ['last 1 chrome versions']
+      };
+
+      let polyfills = this.addon._requiredPolyfills();
+
+      // chrome only gets the `defaultWebIncludes`
+      expect(polyfills.length).to.be.lt(allKnownPolyfills.length);
+    });
+  });
+
+  describe('treeForVendor', function() {
+    let output, subject;
+
+    this.timeout(100000);
+
+    afterEach(co.wrap(function* () {
+      yield output.dispose();
+    }));
+
+    it("should include polyfills for target platform", co.wrap(function* () {
+      this.addon.parent.options = { 'ember-cli-babel': { includePolyfill: true } };
+
+      subject = this.addon.treeForVendor();
+      output = createBuilder(subject);
+
+      yield output.build();
+
+      let files = walkSync(output.path(), { directories: false });
+      expect(files).to.deep.equal(['ember-cli-babel/polyfill.js']);
+    }));
+
+    it("should return undefined when `includePolyfill` is false", function() {
+      this.addon.parent.options = { 'ember-cli-babel': { includePolyfill: false } };
+
+      subject = this.addon.treeForVendor();
+
+      expect(subject).to.be.undefined;
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -41,10 +41,16 @@
     "babel-polyfill": "^6.16.0",
     "babel-preset-env": "^1.2.0",
     "broccoli-babel-transpiler": "^6.0.0",
+    "broccoli-file-creator": "^1.1.1",
     "broccoli-funnel": "^1.0.0",
+    "broccoli-merge-trees": "^2.0.0",
+    "broccoli-rollup": "^1.3.0",
     "broccoli-source": "^1.1.0",
     "clone": "^2.0.0",
-    "ember-cli-version-checker": "^1.2.0"
+    "core-js": "^2.4.1",
+    "ember-cli-version-checker": "^1.2.0",
+    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup-plugin-node-resolve": "^3.0.0"
   },
   "devDependencies": {
     "broccoli-test-helper": "^1.1.0",
@@ -64,7 +70,8 @@
     "ember-resolver": "^2.1.0",
     "loader.js": "4.0.11",
     "mocha": "^3.2.0",
-    "resolve": "^1.3.2"
+    "resolve": "^1.3.2",
+    "walk-sync": "^0.3.1"
   },
   "engines": {
     "node": "^4.5 || 6.* || 7.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,7 +17,7 @@ accepts@1.3.3, accepts@~1.3.3:
     mime-types "~2.1.11"
     negotiator "0.6.1"
 
-acorn@^4.0.3:
+acorn@^4.0.1, acorn@^4.0.3:
   version "4.0.11"
   resolved "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
 
@@ -1010,6 +1010,17 @@ broccoli-config-replace@^1.1.2:
     debug "^2.2.0"
     fs-extra "^0.24.0"
 
+broccoli-file-creator@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.1.1.tgz#1b35b67d215abdfadd8d49eeb69493c39e6c3450"
+  dependencies:
+    broccoli-kitchen-sink-helpers "~0.2.0"
+    broccoli-plugin "^1.1.0"
+    broccoli-writer "~0.1.1"
+    mkdirp "^0.5.1"
+    rsvp "~3.0.6"
+    symlink-or-copy "^1.0.1"
+
 broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
@@ -1033,7 +1044,7 @@ broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-kitchen-sink-helpers@^0.2.5:
+broccoli-kitchen-sink-helpers@^0.2.5, broccoli-kitchen-sink-helpers@~0.2.0:
   version "0.2.9"
   resolved "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz#a5e0986ed8d76fb5984b68c3f0450d3a96e36ecc"
   dependencies:
@@ -1059,6 +1070,13 @@ broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^
     heimdalljs-logger "^0.1.7"
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
+
+broccoli-merge-trees@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz#10aea46dd5cebcc8b8f7d5a54f0a84a4f0bb90b9"
+  dependencies:
+    broccoli-plugin "^1.3.0"
+    merge-trees "^1.0.1"
 
 broccoli-middleware@^1.0.0-beta.8:
   version "1.0.0-beta.8"
@@ -1098,7 +1116,7 @@ broccoli-plugin@1.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.0.1"
 
-broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.3.0:
+broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz#bee704a8e42da08cb58e513aaa436efb7f0ef1ee"
   dependencies:
@@ -1106,6 +1124,22 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.3.0:
     quick-temp "^0.1.3"
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
+
+broccoli-rollup@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-1.3.0.tgz#43a0a7798555bab54217009eb470a4ff5a056df0"
+  dependencies:
+    broccoli-plugin "^1.2.1"
+    es6-map "^0.1.4"
+    fs-extra "^0.30.0"
+    fs-tree-diff "^0.5.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    md5-hex "^1.3.0"
+    node-modules-path "^1.0.1"
+    rollup "^0.41.4"
+    symlink-or-copy "^1.1.8"
+    walk-sync "^0.3.1"
 
 broccoli-slow-trees@^2.0.0:
   version "2.0.0"
@@ -1153,6 +1187,13 @@ broccoli-test-helper@^1.1.0:
     rsvp "^3.3.3"
     walk-sync "^0.3.1"
 
+broccoli-writer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-writer/-/broccoli-writer-0.1.1.tgz#d4d71aa8f2afbc67a3866b91a2da79084b96ab2d"
+  dependencies:
+    quick-temp "^0.1.0"
+    rsvp "^3.0.6"
+
 broccoli@^1.1.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/broccoli/-/broccoli-1.1.1.tgz#0287e72994363777bdfd4e8c71805125337c2bf7"
@@ -1172,6 +1213,12 @@ broccoli@^1.1.0:
     sane "^1.4.1"
     tmp "0.0.28"
     underscore.string "^3.2.2"
+
+browser-resolve@^1.11.0:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+  dependencies:
+    resolve "1.1.7"
 
 browser-stdout@1.3.0:
   version "1.3.0"
@@ -1193,6 +1240,10 @@ bser@1.0.2:
 buffer-shims@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
+
+builtin-modules@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
 bytes@1:
   version "1.0.0"
@@ -1536,9 +1587,9 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0:
+core-js@^2.4.0, core-js@^2.4.1:
   version "2.4.1"
-  resolved "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
 core-object@^1.1.0:
   version "1.1.0"
@@ -1573,6 +1624,12 @@ cryptiles@2.x.x:
   resolved "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
   dependencies:
     boom "2.x.x"
+
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  dependencies:
+    es5-ext "^0.10.9"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -2076,6 +2133,49 @@ error@^7.0.0:
     string-template "~0.2.1"
     xtend "~4.0.0"
 
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.15"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.15.tgz#c330a5934c1ee21284a7c081a86e5fd937c91ea6"
+  dependencies:
+    es6-iterator "2"
+    es6-symbol "~3.1"
+
+es6-iterator@2, es6-iterator@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-symbol "^3.1"
+
+es6-map@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-set "~0.1.5"
+    es6-symbol "~3.1.1"
+    event-emitter "~0.3.5"
+
+es6-set@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-symbol "3.1.1"
+    event-emitter "~0.3.5"
+
+es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@~3.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -2100,6 +2200,10 @@ esprima@^3.1.1, esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
+estree-walker@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.1.tgz#e6b1a51cf7292524e7237c312e5fe6660c1ce1aa"
+
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
@@ -2107,6 +2211,13 @@ esutils@^2.0.0, esutils@^2.0.2:
 etag@~1.8.0:
   version "1.8.0"
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz#6f631aef336d6c46362b51764044ce216be3c051"
+
+event-emitter@~0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 eventemitter3@1.x.x:
   version "1.2.0"
@@ -2862,6 +2973,10 @@ is-integer@^1.0.4:
   dependencies:
     is-finite "^1.0.0"
 
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+
 is-number@^2.0.2, is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -3298,6 +3413,12 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
+magic-string@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.19.0.tgz#198948217254e3e0b93080e01146b7c73b2a06b2"
+  dependencies:
+    vlq "^0.2.1"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -3340,7 +3461,7 @@ matcher-collection@^1.0.0:
   dependencies:
     minimatch "^3.0.2"
 
-md5-hex@^1.0.2:
+md5-hex@^1.0.2, md5-hex@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz#d2c4afe983c4370662179b8cad145219135046c4"
   dependencies:
@@ -3368,6 +3489,17 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
+merge-trees@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-trees/-/merge-trees-1.0.1.tgz#ccbe674569787f9def17fd46e6525f5700bbd23e"
+  dependencies:
+    can-symlink "^1.0.0"
+    fs-tree-diff "^0.5.4"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
+
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -3376,7 +3508,7 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-micromatch@^2.1.5, micromatch@^2.3.7:
+micromatch@^2.1.5, micromatch@^2.3.11, micromatch@^2.3.7:
   version "2.3.11"
   resolved "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -3503,7 +3635,7 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-modules-path@^1.0.0:
+node-modules-path@^1.0.0, node-modules-path@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/node-modules-path/-/node-modules-path-1.0.1.tgz#40096b08ce7ad0ea14680863af449c7c75a5d1c8"
 
@@ -3815,7 +3947,7 @@ qs@6.4.0, qs@^6.2.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-quick-temp@0.1.6, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5:
+quick-temp@0.1.6, quick-temp@^0.1.0, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5:
   version "0.1.6"
   resolved "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.6.tgz#a6242a15cba9f9cdbd341287b5c569e318eec307"
   dependencies:
@@ -4043,7 +4175,11 @@ resolve-dir@^0.1.0:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
 
-resolve@^1.1.2, resolve@^1.1.6, resolve@^1.3.2:
+resolve@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.1.2, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2:
   version "1.3.2"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
   dependencies:
@@ -4072,9 +4208,45 @@ rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
-rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.2.1, rsvp@^3.3.3:
+rollup-plugin-commonjs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.0.2.tgz#98b1589bfe32a6c0f67790b60c0b499972afed89"
+  dependencies:
+    acorn "^4.0.1"
+    estree-walker "^0.3.0"
+    magic-string "^0.19.0"
+    resolve "^1.1.7"
+    rollup-pluginutils "^2.0.1"
+
+rollup-plugin-node-resolve@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz#8b897c4c3030d5001277b0514b25d2ca09683ee0"
+  dependencies:
+    browser-resolve "^1.11.0"
+    builtin-modules "^1.1.0"
+    is-module "^1.0.0"
+    resolve "^1.1.6"
+
+rollup-pluginutils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz#7ec95b3573f6543a46a6461bd9a7c544525d0fc0"
+  dependencies:
+    estree-walker "^0.3.0"
+    micromatch "^2.3.11"
+
+rollup@^0.41.4:
+  version "0.41.6"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.41.6.tgz#e0d05497877a398c104d816d2733a718a7a94e2a"
+  dependencies:
+    source-map-support "^0.4.0"
+
+rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.2.1, rsvp@^3.3.3:
   version "3.5.0"
   resolved "https://registry.npmjs.org/rsvp/-/rsvp-3.5.0.tgz#a62c573a4ae4e1dfd0697ebc6242e79c681eaa34"
+
+rsvp@~3.0.6:
+  version "3.0.21"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.0.21.tgz#49c588fe18ef293bcd0ab9f4e6756e6ac433359f"
 
 rsvp@~3.2.1:
   version "3.2.1"
@@ -4269,7 +4441,7 @@ source-map-support@^0.2.10:
   dependencies:
     source-map "0.1.32"
 
-source-map-support@^0.4.2:
+source-map-support@^0.4.0, source-map-support@^0.4.2:
   version "0.4.14"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz#9d4463772598b86271b4f523f6c1f4e02a7d6aef"
   dependencies:
@@ -4682,6 +4854,10 @@ verror@1.3.6:
   resolved "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
   dependencies:
     extsprintf "1.0.2"
+
+vlq@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.2.tgz#e316d5257b40b86bb43cb8d5fea5d7f54d6b0ca1"
 
 walk-sync@0.3.1, walk-sync@^0.3.0, walk-sync@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
Instead of importing the full `babel-polyfill` we create a polyfill that supports the specific targets the app has declared.

This dramatically reduces the cost of setting `includePolyfill: true` when your targets are newer. For example, with `last 1 chrome versions` as the list of targets, you save 4kb after min+gz (roughly 50% of the total polyfill size).

TODO:

- [ ] Fix CI
- [ ] Ensure we add `regeneratorRuntime` when needed by the given targets.
