### PR TITLE
Misc Updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,7 +237,8 @@ module.exports = {
       },
 
       debugTools: {
-        source: '@ember/debug'
+        source: '@ember/debug',
+        assertPredicateIndex: 1
       }
     };
 

--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ module.exports = {
     return (this.parent && this.parent.options) || (this.app && this.app.options) || {};
   },
 
-  _getAddonProvidedConfig: function(addonOptions) {
+  _parentName() {
     let parentName;
 
     if (this.parent) {
@@ -132,6 +132,10 @@ module.exports = {
       }
     }
 
+    return parentName;
+  },
+
+  _getAddonProvidedConfig(addonOptions) {
     let babelOptions = clone(addonOptions.babel || {});
 
     // used only to support using ember-cli-babel@6 at the
@@ -170,7 +174,12 @@ module.exports = {
     let addonProvidedConfig = this._getAddonProvidedConfig(config);
     let shouldCompileModules = this._shouldCompileModules(config);
 
-    let options = {};
+    let providedAnnotation = config['ember-cli-babel'] && config['ember-cli-babel'].annotation;
+
+    let options = {
+      annotation: providedAnnotation || `Babel: ${this._parentName()}`
+    };
+
     let userPlugins = addonProvidedConfig.plugins;
     let userPostTransformPlugins = addonProvidedConfig.postTransformPlugins;
 

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -144,7 +144,7 @@ describe('ember-cli-babel', function() {
           expect(
             output.read()
           ).to.deep.equal({
-            "foo.js": `define('foo', [], function () {\n  'use strict';\n\n  (true && Ember.assert('stuff here', isNotBad()));\n});`
+            "foo.js": `define('foo', [], function () {\n  'use strict';\n\n  (true && !(isNotBad()) && Ember.assert('stuff here', isNotBad()));\n});`
           });
         }));
       });
@@ -190,7 +190,7 @@ describe('ember-cli-babel', function() {
           expect(
             output.read()
           ).to.deep.equal({
-            "foo.js": `define('foo', [], function () {\n  'use strict';\n\n  (false && Ember.assert('stuff here', isNotBad()));\n});`
+            "foo.js": `define('foo', [], function () {\n  'use strict';\n\n  (false && !(isNotBad()) && Ember.assert('stuff here', isNotBad()));\n});`
           });
         }));
       });

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -505,6 +505,33 @@ describe('ember-cli-babel', function() {
       expect(result.babelrc).to.be.false;
     });
 
+    it('provides an annotation including parent name - addon', function() {
+      this.addon.parent = {
+        name: 'derpy-herpy'
+      };
+      let result = this.addon.buildBabelOptions();
+      expect(result.annotation).to.include('derpy-herpy');
+    });
+
+    it('provides an annotation including parent name - project', function() {
+      this.addon.parent = {
+        name() { return 'derpy-herpy'; }
+      };
+      let result = this.addon.buildBabelOptions();
+      expect(result.annotation).to.include('derpy-herpy');
+    });
+
+    it('uses provided annotation if specified', function() {
+      let options = {
+        'ember-cli-babel': {
+          annotation: 'Hello World!'
+        }
+      };
+
+      let result = this.addon.buildBabelOptions(options);
+      expect(result.annotation).to.equal('Hello World!');
+    });
+
     it('does not include all provided options', function() {
       let babelOptions = { blah: true };
       let options = {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-polyfill": "^6.16.0",
     "babel-preset-env": "^1.5.1",
     "broccoli-babel-transpiler": "^6.0.0",
+    "broccoli-debug": "^0.6.2",
     "broccoli-funnel": "^1.0.0",
     "broccoli-source": "^1.1.0",
     "clone": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "amd-name-resolver": "0.0.6",
-    "babel-plugin-debug-macros": "^0.1.7",
+    "babel-plugin-debug-macros": "^0.1.10",
     "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
     "babel-polyfill": "^6.16.0",
     "babel-preset-env": "^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -432,9 +432,15 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.6, babel-plugin-debug-macros@^0.1.7:
+babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.6:
   version "0.1.10"
   resolved "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.10.tgz#dd077ad6e1cc0a8f9bbc6405c561392ebfc9a01c"
+  dependencies:
+    semver "^5.3.0"
+
+babel-plugin-debug-macros@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.10.tgz#dd077ad6e1cc0a8f9bbc6405c561392ebfc9a01c"
   dependencies:
     semver "^5.3.0"
 
@@ -939,19 +945,7 @@ broccoli-config-replace@^1.1.2:
     debug "^2.2.0"
     fs-extra "^0.24.0"
 
-broccoli-debug@^0.6.1:
-  version "0.6.2"
-  resolved "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.2.tgz#4c6e89459fc3de7d5d4fc7b77e57f46019f44db1"
-  dependencies:
-    broccoli-plugin "^1.2.1"
-    fs-tree-diff "^0.5.2"
-    heimdalljs "^0.2.1"
-    heimdalljs-logger "^0.1.7"
-    minimatch "^3.0.3"
-    symlink-or-copy "^1.1.8"
-    tree-sync "^1.2.2"
-
-broccoli-debug@^0.6.2:
+broccoli-debug@^0.6.1, broccoli-debug@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.2.tgz#4c6e89459fc3de7d5d4fc7b77e57f46019f44db1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,6 +951,18 @@ broccoli-debug@^0.6.1:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
+broccoli-debug@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.2.tgz#4c6e89459fc3de7d5d4fc7b77e57f46019f44db1"
+  dependencies:
+    broccoli-plugin "^1.2.1"
+    fs-tree-diff "^0.5.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    minimatch "^3.0.3"
+    symlink-or-copy "^1.1.8"
+    tree-sync "^1.2.2"
+
 broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"


### PR DESCRIPTION
* Update README to be less confusing about addon usage.
* Update babel-plugin-debug-macros to latest version, and configure properly so that assertion predicates can be checked prior to assertion message generation.
* Add `broccoli-debug` tooling (enables debugging input and output tree's via `BROCCOLI_DEBUG=ember-cli-babel:* ember b`).
* Provide useful annotation to underlying `broccoli-babel-transpiler`. Prior to this all instrumentation just says `Babel`, now it will say `Babel: parent-addon-name`.

Fixes https://github.com/babel/ember-cli-babel/issues/146