### PR TITLE
Add emberjs/rfcs#176 support by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ interface EmberCLIBabelConfig {
     includePolyfill?: boolean;
     compileModules?: boolean;
     disableDebugTooling?: boolean;
+    disableEmberModulesAPIPolyfill?: boolean;
   };
 }
 ```

--- a/index.js
+++ b/index.js
@@ -208,6 +208,7 @@ module.exports = {
     options.plugins = [].concat(
       userPlugins,
       this._getDebugMacroPlugins(config),
+      this._getEmberModulesAPIPolyfill(config),
       shouldCompileModules && this._getModulesPlugin(),
       this._getPresetEnvPlugins(addonProvidedConfig),
       userPostTransformPlugins
@@ -249,6 +250,18 @@ module.exports = {
     };
 
     return [[DebugMacros, options]];
+  },
+
+  _getEmberModulesAPIPolyfill(config) {
+    let addonOptions = config['ember-cli-babel'] || {};
+
+    if (addonOptions.disableEmberModulesAPIPolyfill) { return; }
+
+    if (this._emberVersionRequiresModulesAPIPolyfill()) {
+      const ModulesAPIPolyfill = require('babel-plugin-ember-modules-api-polyfill');
+
+      return [[ModulesAPIPolyfill]];
+    }
   },
 
   _getPresetEnvPlugins(config) {
@@ -329,4 +342,10 @@ module.exports = {
     }
   },
 
+  _emberVersionRequiresModulesAPIPolyfill() {
+    // once a version of Ember ships with the
+    // emberjs/rfcs#176 modules natively this will
+    // be updated to detect that and return false
+    return true;
+  }
 };

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -71,6 +71,47 @@ describe('ember-cli-babel', function() {
       });
     }));
 
+    describe('ember modules API polyfill', function() {
+      it("can opt-out via ember-cli-babel.disableEmberModulesAPIPolyfill", co.wrap(function* () {
+        input.write({
+          "foo.js": `import Component from '@ember/component';`
+        });
+
+        subject = this.addon.transpileTree(input.path(), {
+          'ember-cli-babel': {
+            disableEmberModulesAPIPolyfill: true
+          }
+        });
+
+        output = createBuilder(subject);
+
+        yield output.build();
+
+        expect(
+          output.read()
+        ).to.deep.equal({
+          "foo.js": `define('foo', ['@ember/component'], function (_component) {\n  'use strict';\n});`
+        });
+      }));
+
+      it("should replace imports by default", co.wrap(function* () {
+        input.write({
+          "foo.js": `import Component from '@ember/component';`
+        });
+
+        subject = this.addon.transpileTree(input.path());
+        output = createBuilder(subject);
+
+        yield output.build();
+
+        expect(
+          output.read()
+        ).to.deep.equal({
+          "foo.js": `define('foo', [], function () {\n  'use strict';\n\n  var Component = Ember.Component;\n});`
+        });
+      }));
+    });
+
     describe('debug macros', function() {
       it("can opt-out via ember-cli-babel.disableDebugTooling", co.wrap(function* () {
         process.env.EMBER_ENV = 'development';

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "amd-name-resolver": "0.0.6",
     "babel-plugin-debug-macros": "^0.1.10",
+    "babel-plugin-ember-modules-api-polyfill": "^1.2.0",
     "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
     "babel-polyfill": "^6.16.0",
     "babel-preset-env": "^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -432,17 +432,17 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.6:
-  version "0.1.10"
-  resolved "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.10.tgz#dd077ad6e1cc0a8f9bbc6405c561392ebfc9a01c"
-  dependencies:
-    semver "^5.3.0"
-
-babel-plugin-debug-macros@^0.1.10:
+babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.6:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.10.tgz#dd077ad6e1cc0a8f9bbc6405c561392ebfc9a01c"
   dependencies:
     semver "^5.3.0"
+
+babel-plugin-ember-modules-api-polyfill@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.2.0.tgz#f99f26040d4d29ae42fdc333553198940d59cf46"
+  dependencies:
+    ember-rfc176-data "^0.1.0"
 
 babel-plugin-htmlbars-inline-precompile@^0.2.3:
   version "0.2.3"
@@ -1903,6 +1903,10 @@ ember-resolver@^4.0.0:
     ember-cli-babel "^6.0.0-beta.7"
     ember-cli-version-checker "^1.1.6"
     resolve "^1.3.2"
+
+ember-rfc176-data@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.1.0.tgz#e248824d9bc41f63053fd52da0452ddcf16a044a"
 
 ember-router-generator@^1.0.0:
   version "1.2.3"


### PR DESCRIPTION
This replaces the new modules with globals usage when the Ember version in use does not include its own modules.

As discussed in a recent ember-cli team meeting.