### PR TITLE
Avoid conflicting transforms for @ember/debug.

### DIFF
--- a/index.js
+++ b/index.js
@@ -260,7 +260,7 @@ module.exports = {
     if (this._emberVersionRequiresModulesAPIPolyfill()) {
       const ModulesAPIPolyfill = require('babel-plugin-ember-modules-api-polyfill');
 
-      return [[ModulesAPIPolyfill, { blacklist: ['@ember/debug'] }]];
+      return [[ModulesAPIPolyfill, { blacklist: { '@ember/debug': ['assert', 'deprecate', 'warn']} }]];
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -260,7 +260,7 @@ module.exports = {
     if (this._emberVersionRequiresModulesAPIPolyfill()) {
       const ModulesAPIPolyfill = require('babel-plugin-ember-modules-api-polyfill');
 
-      return [[ModulesAPIPolyfill]];
+      return [[ModulesAPIPolyfill, { blacklist: ['@ember/debug'] }]];
     }
   },
 

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -144,6 +144,7 @@ describe('ember-cli-babel', function() {
 
         let contents = output.read()['foo.js'];
 
+        expect(contents).to.not.include('@ember/debug');
         expect(contents).to.include('function _asyncToGenerator');
         expect(contents).to.include('var inspect = Ember.inspect;');
         expect(contents).to.not.include('assert');

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -96,7 +96,8 @@ describe('ember-cli-babel', function() {
 
       it("should replace imports by default", co.wrap(function* () {
         input.write({
-          "foo.js": `import Component from '@ember/component';`
+          "foo.js": `import Component from '@ember/component';`,
+          "app.js": `import Application from '@ember/application';`
         });
 
         subject = this.addon.transpileTree(input.path());
@@ -107,7 +108,8 @@ describe('ember-cli-babel', function() {
         expect(
           output.read()
         ).to.deep.equal({
-          "foo.js": `define('foo', [], function () {\n  'use strict';\n\n  var Component = Ember.Component;\n});`
+          "foo.js": `define('foo', [], function () {\n  'use strict';\n\n  var Component = Ember.Component;\n});`,
+          "app.js": `define('app', [], function () {\n  'use strict';\n\n  var Application = Ember.Application;\n});`
         });
       }));
 

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -110,6 +110,24 @@ describe('ember-cli-babel', function() {
           "foo.js": `define('foo', [], function () {\n  'use strict';\n\n  var Component = Ember.Component;\n});`
         });
       }));
+
+      it("does not remove _asyncToGenerator helper function when used together with debug-macros", co.wrap(function* () {
+        input.write({
+          "foo.js": stripIndent`
+            import { assert } from '@ember/debug';
+            export default { async foo() { await this.baz; }}
+          `
+        });
+
+        subject = this.addon.transpileTree(input.path());
+        output = createBuilder(subject);
+
+        yield output.build();
+
+        let contents = output.read()['foo.js'];
+
+        expect(contents).to.include('function _asyncToGenerator');
+      }));
     });
 
     describe('debug macros', function() {

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -128,6 +128,26 @@ describe('ember-cli-babel', function() {
 
         expect(contents).to.include('function _asyncToGenerator');
       }));
+
+      it("allows @ember/debug to be consumed via both debug-macros and ember-modules-api-polyfill", co.wrap(function* () {
+        input.write({
+          "foo.js": stripIndent`
+            import { assert, inspect } from '@ember/debug';
+            export default { async foo() { await this.baz; }}
+          `
+        });
+
+        subject = this.addon.transpileTree(input.path());
+        output = createBuilder(subject);
+
+        yield output.build();
+
+        let contents = output.read()['foo.js'];
+
+        expect(contents).to.include('function _asyncToGenerator');
+        expect(contents).to.include('var inspect = Ember.inspect;');
+        expect(contents).to.not.include('assert');
+      }));
     });
 
     describe('debug macros', function() {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "amd-name-resolver": "0.0.6",
     "babel-plugin-debug-macros": "^0.1.10",
-    "babel-plugin-ember-modules-api-polyfill": "^1.3.0",
+    "babel-plugin-ember-modules-api-polyfill": "^1.4.1",
     "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
     "babel-polyfill": "^6.16.0",
     "babel-preset-env": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "amd-name-resolver": "0.0.6",
-    "babel-plugin-debug-macros": "^0.1.10",
+    "babel-plugin-debug-macros": "^0.1.11",
     "babel-plugin-ember-modules-api-polyfill": "^1.4.1",
     "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
     "babel-polyfill": "^6.16.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "amd-name-resolver": "0.0.6",
     "babel-plugin-debug-macros": "^0.1.10",
-    "babel-plugin-ember-modules-api-polyfill": "^1.2.0",
+    "babel-plugin-ember-modules-api-polyfill": "^1.3.0",
     "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
     "babel-polyfill": "^6.16.0",
     "babel-preset-env": "^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -438,9 +438,9 @@ babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.10, babel-plugi
   dependencies:
     semver "^5.3.0"
 
-babel-plugin-ember-modules-api-polyfill@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.2.0.tgz#f99f26040d4d29ae42fdc333553198940d59cf46"
+babel-plugin-ember-modules-api-polyfill@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.3.0.tgz#0b32e3dfdee47f26942968f49d2d67ba85346ae3"
   dependencies:
     ember-rfc176-data "^0.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -432,9 +432,9 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.6:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.10.tgz#dd077ad6e1cc0a8f9bbc6405c561392ebfc9a01c"
+babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.11, babel-plugin-debug-macros@^0.1.6:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz#6c562bf561fccd406ce14ab04f42c218cf956605"
   dependencies:
     semver "^5.3.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -438,9 +438,9 @@ babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.10, babel-plugi
   dependencies:
     semver "^5.3.0"
 
-babel-plugin-ember-modules-api-polyfill@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.3.0.tgz#0b32e3dfdee47f26942968f49d2d67ba85346ae3"
+babel-plugin-ember-modules-api-polyfill@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.4.1.tgz#2b05e1b37e492449319a9cc2bdca460cda70b5b1"
   dependencies:
     ember-rfc176-data "^0.1.0"
 


### PR DESCRIPTION
When both babel-plugin-debug-macros and babel-plugin-ember-modules-api-polyfill attempt to replace `import { assert } from '@ember/assert';` the interaction between the two also removes any helpers that are injected by other parts of the transpilation (e.g. `_classCallCheck` or `_asyncToGenerator`) therefore making the transpiled output fail at runtime.

This updates babel-plugin-ember-modules-api-polyfill to a version that allows specifying a blacklist so that we can avoid this conflict.

Fixes https://github.com/babel/ember-cli-babel/issues/160