### PR TITLE
Removes the flag MODEL_FACTORY_INJECTIONS

### DIFF
--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,11 +3,10 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
+const { Application } = Ember;
 let App;
 
-Ember.MODEL_FACTORY_INJECTIONS = true;
-
-App = Ember.Application.extend({
+App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver


### PR DESCRIPTION
Removing this flag due to warning

This flag is needless for project with ember-cli >= 2.13 

https://emberjs.com/deprecations/v2.x/#toc_id-ember-metal-model_factory_injections