### PR TITLE
Update minimum version of babel-plugin-ember-modules-api-polyfill.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "amd-name-resolver": "0.0.7",
     "babel-plugin-debug-macros": "^0.1.11",
-    "babel-plugin-ember-modules-api-polyfill": "^1.4.1",
+    "babel-plugin-ember-modules-api-polyfill": "^1.5.0",
     "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
     "babel-polyfill": "^6.16.0",
     "babel-preset-env": "^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,6 +140,12 @@ amd-name-resolver@0.0.6:
   dependencies:
     ensure-posix-path "^1.0.1"
 
+amd-name-resolver@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz#814301adfe8a2f109f6e84d5e935196efb669615"
+  dependencies:
+    ensure-posix-path "^1.0.1"
+
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
@@ -493,6 +499,12 @@ babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.11:
 babel-plugin-ember-modules-api-polyfill@^1.4.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.4.2.tgz#e254f8ed0ba7cf32ea6a71c4770b3568a8577402"
+  dependencies:
+    ember-rfc176-data "^0.2.0"
+
+babel-plugin-ember-modules-api-polyfill@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.5.0.tgz#5ab880597d44118ee56c21d143f75f245efd4e95"
   dependencies:
     ember-rfc176-data "^0.2.0"
 


### PR DESCRIPTION
This now provides `import Ember from 'ember'` (and therefore removes the requirement of addons and/or apps to have `ember-cli-shims` installed).

