### PR TITLE
Support Node 8 in package.engines

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
     - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "7"
-    # - nodejs_version: "8"
+    - nodejs_version: "8"
 
 cache:
   - '%APPDATA%\npm-cache'

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "resolve": "^1.3.3"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "^4.5 || 6.* || >= 7.* || >= 8.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Currently `ember-cli-babel` fails to install using `yarn` on Node 8 due to overly restrictive `engines` definition, however it seems to function perfectly well.