### PR TITLE
Properly detect host ember-cli version.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 const VersionChecker = require('ember-cli-version-checker');
 const clone = require('clone');
 const path = require('path');
+const semver = require('semver');
 
 let count = 0;
 
@@ -339,7 +340,7 @@ module.exports = {
 
       return babelOptions.compileModules;
     } else {
-      return this.emberCLIChecker.gt('2.12.0-alpha.1');
+      return semver.gt(this.project.emberCLIVersion, '2.12.0-alpha.1');
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -351,10 +351,10 @@ module.exports = {
   },
 
   _getEmberModulesAPIBlacklist() {
-    const blacklist = { 
+    const blacklist = {
       '@ember/debug': ['assert', 'deprecate', 'warn'],
     };
-    
+
     if (this._emberStringDependencyPresent()) {
       blacklist['@ember/string'] = [
         'fmt', 'loc', 'w',

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -20,7 +20,7 @@ describe('ember-cli-babel', function() {
 
   beforeEach(function() {
     this.ui = new MockUI();
-    let project = { root: __dirname };
+    let project = { root: __dirname, emberCLIVersion: '2.16.2' };
     this.addon = new Addon({
       project,
       parent: project,
@@ -280,7 +280,7 @@ describe('ember-cli-babel', function() {
 
     describe('@ember/string detection', function() {
       beforeEach(function() {
-        let project = { root: input.path() };
+        let project = { root: input.path(), emberCLIVersion: '2.16.2' };
         this.addon = new Addon({
           project,
           parent: project,
@@ -504,13 +504,13 @@ describe('ember-cli-babel', function() {
 
     describe('without any compileModules option set', function() {
       it('returns false for ember-cli < 2.12', function() {
-        this.addon.emberCLIChecker = { gt() { return false; } };
+        this.addon.project.emberCLIVersion = '2.11.1';
 
         expect(this.addon.shouldCompileModules()).to.eql(false);
       });
 
       it('returns true for ember-cli > 2.12.0-alpha.1', function() {
-        this.addon.emberCLIChecker = { gt() { return true; } };
+        this.addon.project.emberCLIVersion = '2.13.0';
 
         expect(this.addon.shouldCompileModules()).to.be.true;
       });

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "broccoli-funnel": "^1.0.0",
     "broccoli-source": "^1.1.0",
     "clone": "^2.0.0",
-    "ember-cli-version-checker": "^2.1.0"
+    "ember-cli-version-checker": "^2.1.0",
+    "semver": "^5.4.1"
   },
   "devDependencies": {
     "broccoli-test-helper": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4888,7 +4888,7 @@ sane@^1.1.1, sane@^1.4.1, sane@^1.6.0:
     walker "~1.0.5"
     watch "~0.10.0"
 
-"semver@2 || 3 || 4 || 5":
+"semver@2 || 3 || 4 || 5", semver@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 


### PR DESCRIPTION
When running in a linked environment, the standard `require.resovle` technique to determine the currently running ember-cli version does not work properly (because the linked addon's ember-cli dev dependency will be found instead of the _actual_ running ember-cli from the project).

The most common symptom of this issue is that modules are "double transpiled" (e.g. you have an AMD wrapped module _inside_ of another AMD wrapper).