### PR TITLE
Update babel-plugin-ember-modules-api-polyfill to 2.3.0.

### DIFF
--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -96,8 +96,8 @@ describe('ember-cli-babel', function() {
 
       it("should replace imports by default", co.wrap(function* () {
         input.write({
-          "foo.js": `import Component from '@ember/component';`,
-          "app.js": `import Application from '@ember/application';`
+          "foo.js": `import Component from '@ember/component'; Component.extend()`,
+          "app.js": `import Application from '@ember/application'; Application.extend()`
         });
 
         subject = this.addon.transpileTree(input.path());
@@ -108,8 +108,8 @@ describe('ember-cli-babel', function() {
         expect(
           output.read()
         ).to.deep.equal({
-          "foo.js": `define('foo', [], function () {\n  'use strict';\n\n  var Component = Ember.Component;\n});`,
-          "app.js": `define('app', [], function () {\n  'use strict';\n\n  var Application = Ember.Application;\n});`
+          "foo.js": `define('foo', [], function () {\n  'use strict';\n\n  Ember.Component.extend();\n});`,
+          "app.js": `define('app', [], function () {\n  'use strict';\n\n  Ember.Application.extend();\n});`
         });
       }));
 
@@ -135,7 +135,7 @@ describe('ember-cli-babel', function() {
         input.write({
           "foo.js": stripIndent`
             import { assert, inspect } from '@ember/debug';
-            export default { async foo() { await this.baz; }}
+            export default { async foo() { inspect(await this.baz); }}
           `
         });
 
@@ -148,7 +148,7 @@ describe('ember-cli-babel', function() {
 
         expect(contents).to.not.include('@ember/debug');
         expect(contents).to.include('function _asyncToGenerator');
-        expect(contents).to.include('var inspect = Ember.inspect;');
+        expect(contents).to.include('Ember.inspect;');
         expect(contents).to.not.include('assert');
       }));
     });
@@ -338,7 +338,7 @@ describe('ember-cli-babel', function() {
         expect(
           output.read()
         ).to.deep.equal({
-          "foo.js": `define('foo', [], function () {\n  'use strict';\n\n  var camelize = Ember.String.camelize;\n\n  camelize('stuff-here');\n});`
+          "foo.js": `define('foo', [], function () {\n  'use strict';\n\n  Ember.String.camelize('stuff-here');\n});`
         });
       }));
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "amd-name-resolver": "0.0.7",
     "babel-plugin-debug-macros": "^0.1.11",
-    "babel-plugin-ember-modules-api-polyfill": "^2.0.1",
+    "babel-plugin-ember-modules-api-polyfill": "^2.3.0",
     "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
     "babel-polyfill": "^6.16.0",
     "babel-preset-env": "^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,11 +518,11 @@ babel-plugin-ember-modules-api-polyfill@^1.4.1:
   dependencies:
     ember-rfc176-data "^0.2.0"
 
-babel-plugin-ember-modules-api-polyfill@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.0.1.tgz#baaf26dcebe2ed1de120021bc42be29f520497b3"
+babel-plugin-ember-modules-api-polyfill@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz#0c01f359658cfb9c797f705af6b09f6220205ae0"
   dependencies:
-    ember-rfc176-data "^0.2.7"
+    ember-rfc176-data "^0.3.0"
 
 babel-plugin-htmlbars-inline-precompile@^0.2.3:
   version "0.2.3"
@@ -2157,9 +2157,9 @@ ember-rfc176-data@^0.2.0:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.2.5.tgz#b26f62d9c03d3b02485153cf31137e089299839a"
 
-ember-rfc176-data@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz#bd355bc9b473e08096b518784170a23388bc973b"
+ember-rfc176-data@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.1.tgz#6a5a4b8b82ec3af34f3010965fa96b936ca94519"
 
 ember-router-generator@^1.0.0:
   version "1.2.3"


### PR DESCRIPTION
The primary change here is that imports are lazily accessed where used, instead of creating a variable for the import eagerly.

In practice this doesn't matter very much to folks, but in some circumstances a given import may or may not end up being present (e.g.  `Ember.Test.registerWaiter`). The prior system would throw an error in production builds when `import { registerWaiter } from '@ember/test';` was used (due to the mechanism the prior version of the polyfill worked) even if that import was only used in an `if (DEBUG) {` style guard.

This update fixes that issue...