### PR TITLE
Remove redundant check for targets

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,7 +299,7 @@ module.exports = {
   },
 
   _getTargets() {
-    let targets = this.project && this.project.targets && this.project.targets;
+    let targets = this.project && this.project.targets;
 
     let parser = require('babel-preset-env/lib/targets-parser').default;
     if (typeof targets === 'object' && targets !== null) {


### PR DESCRIPTION
Hi,

Spotted this while going through the source of ember-cli-babel. Looks like it was introduced while [adding tests for isPluginRequired](https://github.com/babel/ember-cli-babel/commit/f6fabd72633a5d8174d2a07be6a93469b8513042#diff-168726dbe96b3ce427e7fedce31bb0bcR192).