### PR TITLE
Respect babel retainLines option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ interface EmberCLIBabelConfig {
     exclude?: string[];
     useBuiltIns?: boolean;
     sourceMaps?: boolean | "inline" | "both";
+    retainLines?: boolean;
     plugins?: BabelPlugin[];
   };
 
@@ -155,6 +156,22 @@ To enable it, pass `sourceMaps: 'inline'` in your `babel` options.
 var app = new EmberApp(defaults, {
   babel: {
     sourceMaps: 'inline'
+  }
+});
+```
+
+#### Enabling Retain Lines
+
+Babel generated source maps will enable you to debug your original ES6 source code. This is disabled by default because this will lead to wacky code but is handy for scenarios where you can't use source maps or breakpoints in external debugger are offset (vscode has this issue, see the extension https://github.com/Microsoft/vscode-chrome-debug)
+
+To enable it, pass `retainLines: true` in your `babel` options.
+
+```js
+// ember-cli-build.js
+
+var app = new EmberApp(defaults, {
+  babel: {
+    retainLines: true
   }
 });
 ```

--- a/index.js
+++ b/index.js
@@ -211,10 +211,12 @@ module.exports = {
       sourceMaps = config.babel.sourceMaps;
     }
 
-    let options = {
-      annotation: providedAnnotation || `Babel: ${this._parentName()}`,
-      sourceMaps
-    };
+    let retainLines = false;
+    if (config.babel && "retainLines" in config.babel) {
+      retainLines = config.babel.retainLines;
+    }
+
+    let options = { annotation: providedAnnotation || `Babel: ${this._parentName()}`, sourceMaps, retainLines };
 
     let userPlugins = addonProvidedConfig.plugins;
     let userPostTransformPlugins = addonProvidedConfig.postTransformPlugins;

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -718,6 +718,13 @@ describe('ember-cli-babel', function() {
       expect(result.sourceMaps).to.equal('inline');
     });
 
+    it("uses provided retainLines if specified", function() {
+      let options = { babel: { retainLines: true } };
+
+      let result = this.addon.buildBabelOptions(options);
+      expect(result.retainLines).to.equal(true);
+    });
+
     it('does not include all provided options', function() {
       let babelOptions = { blah: true };
       let options = {


### PR DESCRIPTION
Hi,

While trying to set ember developing environment with vscode and vscode-debug-chrome extenstion I was facing some issues with setting breakpoints since they where offset in the source code.

I found that this setting allow for correct line mapping and by this solving this issue.
I think that others might find this useful for their development as well.