### PR TITLE
Prints babel 5 deprecation

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
 
   init: function() {
     this._super.init && this._super.init.apply(this, arguments);
+    this.ui.writeDeprecateLine('Write actual deprecation');
 
     var checker = new VersionChecker(this);
     var dep = checker.for('ember-cli', 'npm');

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
 
   init: function() {
     this._super.init && this._super.init.apply(this, arguments);
-    this.ui.writeDeprecateLine('Write actual deprecation');
+    this.ui.writeDeprecateLine('ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6.0');
 
     var checker = new VersionChecker(this);
     var dep = checker.for('ember-cli', 'npm');

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -17,10 +17,10 @@ describe('ember-cli-babel', function() {
     });
   });
 
-  describe('Deprecate ember-cli-babel 5', function() {
-    it('should always print deprecaiton', function() {
+  describe('init()', function() {
+    it('should always print deprecation for version 5.x', function() {
       var deprecationMessages = this.ui.output.split('\n').filter(function(line) {
-        return line.indexOf('Write actual deprecation') !== -1;
+        return line.indexOf('ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6.0') !== -1;
       });
 
       expect(deprecationMessages).to.have.lengthOf(1);

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -17,6 +17,16 @@ describe('ember-cli-babel', function() {
     });
   });
 
+  describe('Deprecate ember-cli-babel 5', function() {
+    it('should always print deprecaiton', function() {
+      var deprecationMessages = this.ui.output.split('\n').filter(function(line) {
+        return line.indexOf('Write actual deprecation') !== -1;
+      });
+
+      expect(deprecationMessages).to.have.lengthOf(1);
+    });
+  });
+
   describe('shouldIncludePolyfill()', function() {
     describe('without any includePolyfill option set', function() {
       it('should return false', function() {


### PR DESCRIPTION
Relates to https://github.com/ember-cli/ember-cli/issues/7642.

Based on feedback from @Turbo87 we are printing a deprecation message every time this addon runs. This will help any consumers of a `^5.x` version receive a deprecation message.

(Collaborating with @cah-danmonroe)

