### PR TITLE
Add additional checks for deprecation message

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ module.exports = {
 
   init: function() {
     this._super.init && this._super.init.apply(this, arguments);
-    this.ui.writeDeprecateLine('ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6.0');
+    if (typeof this.ui === 'object' && typeof this.ui.writeDeprecateLine === 'function') {
+        this.ui.writeDeprecateLine('ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6.0');
+    }
 
     var checker = new VersionChecker(this);
     var dep = checker.for('ember-cli', 'npm');

--- a/index.js
+++ b/index.js
@@ -12,8 +12,12 @@ module.exports = {
 
   init: function() {
     this._super.init && this._super.init.apply(this, arguments);
+    
+    var deprecationMessage = 'ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6.0';
     if (typeof this.ui === 'object' && typeof this.ui.writeDeprecateLine === 'function') {
-        this.ui.writeDeprecateLine('ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6.0');
+        this.ui.writeDeprecateLine(deprecationMessage);
+    } else {
+        console.warn(deprecationMessage);
     }
 
     var checker = new VersionChecker(this);


### PR DESCRIPTION
Some ember-cli environments didn't seem to inject the this.ui
properly, causing this function not to exist. This would cause
and error when starting ember cli.