### PR TITLE
Bumps `broccoli-funnel` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-preset-env": "^1.5.1",
     "broccoli-babel-transpiler": "^6.1.2",
     "broccoli-debug": "^0.6.2",
-    "broccoli-funnel": "^1.0.0",
+    "broccoli-funnel": "^2.0.0",
     "broccoli-source": "^1.1.0",
     "clone": "^2.0.0",
     "ember-cli-version-checker": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,6 +1082,24 @@ broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
+broccoli-funnel@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz#6823c73b675ef78fffa7ab800f083e768b51d449"
+  dependencies:
+    array-equal "^1.0.0"
+    blank-object "^1.0.1"
+    broccoli-plugin "^1.3.0"
+    debug "^2.2.0"
+    fast-ordered-set "^1.0.0"
+    fs-tree-diff "^0.5.3"
+    heimdalljs "^0.2.0"
+    minimatch "^3.0.0"
+    mkdirp "^0.5.0"
+    path-posix "^1.0.0"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
+    walk-sync "^0.3.1"
+
 broccoli-kitchen-sink-helpers@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz#77c7c18194b9664163ec4fcee2793444926e0c06"


### PR DESCRIPTION
This should remove the warning with the `exists-sync` deprecated dependency (https://github.com/broccolijs/broccoli-funnel/pull/100)