### PR TITLE
Avoid eagerly requiring plugins and presets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
   - "10"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,9 @@ init:
 environment:
   MOCHA_REPORTER: "mocha-appveyor-reporter"
   matrix:
-    - nodejs_version: "4"
     - nodejs_version: "6"
-    - nodejs_version: "7"
-    # - nodejs_version: "8"
+    - nodejs_version: "8"
+    - nodejs_version: "10"
 
 cache:
   - '%APPDATA%\npm-cache'

--- a/index.js
+++ b/index.js
@@ -8,16 +8,6 @@ const semver = require('semver');
 
 let count = 0;
 
-function addBaseDir(Plugin) {
-  let type = typeof Plugin;
-
-  if (type === 'function' && !Plugin.baseDir) {
-    Plugin.baseDir = () => __dirname;
-  } else if (type === 'object' && Plugin !== null && Plugin.default) {
-    addBaseDir(Plugin.default);
-  }
-}
-
 module.exports = {
   name: 'ember-cli-babel',
   configKey: 'ember-cli-babel',
@@ -225,9 +215,12 @@ module.exports = {
       this._getDebugMacroPlugins(config),
       this._getEmberModulesAPIPolyfill(config),
       shouldCompileModules && this._getModulesPlugin(),
-      shouldRunPresetEnv && this._getPresetEnvPlugins(addonProvidedConfig),
       userPostTransformPlugins
     ).filter(Boolean);
+
+    options.presets = [
+      shouldRunPresetEnv && this._getPresetEnvPlugins(addonProvidedConfig),
+    ]
 
     if (shouldCompileModules) {
       options.moduleIds = true;
@@ -245,7 +238,6 @@ module.exports = {
 
     if (addonOptions.disableDebugTooling) { return; }
 
-    const DebugMacros = require('babel-plugin-debug-macros').default;
     const isProduction = process.env.EMBER_ENV === 'production';
 
     let options = {
@@ -264,7 +256,7 @@ module.exports = {
       }
     };
 
-    return [[DebugMacros, options]];
+    return [[require.resolve('babel-plugin-debug-macros'), options]];
   },
 
   _getEmberModulesAPIPolyfill(config) {
@@ -273,10 +265,9 @@ module.exports = {
     if (addonOptions.disableEmberModulesAPIPolyfill) { return; }
 
     if (this._emberVersionRequiresModulesAPIPolyfill()) {
-      const ModulesAPIPolyfill = require('babel-plugin-ember-modules-api-polyfill');
       const blacklist = this._getEmberModulesAPIBlacklist();
 
-      return [[ModulesAPIPolyfill, { blacklist }]];
+      return [[require.resolve('babel-plugin-ember-modules-api-polyfill'), { blacklist }]];
     }
   },
 
@@ -289,20 +280,12 @@ module.exports = {
       targets
     });
 
-    let presetEnvPlugins = this._presetEnv(null, presetOptions).plugins;
-
-    presetEnvPlugins.forEach(function(pluginArray) {
-      let Plugin = pluginArray[0];
-      addBaseDir(Plugin);
-    });
-
+    let presetEnvPlugins = this._presetEnv(presetOptions);
     return presetEnvPlugins;
   },
 
-  _presetEnv() {
-    const presetEnv = require('babel-preset-env').default;
-
-    return presetEnv.apply(null, arguments);
+  _presetEnv(presetOptions) {
+    return [require.resolve('babel-preset-env'), presetOptions];
   },
 
   _getTargets() {
@@ -317,12 +300,8 @@ module.exports = {
   },
 
   _getModulesPlugin() {
-    const ModulesTransform = require('babel-plugin-transform-es2015-modules-amd');
-
-    addBaseDir(ModulesTransform);
-
     return [
-      [ModulesTransform, { noInterop: true }],
+      [require.resolve('babel-plugin-transform-es2015-modules-amd'), { noInterop: true }]
     ];
   },
 

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -12,6 +12,7 @@ const stripIndent = CommonTags.stripIndent;
 const BroccoliTestHelper = require('broccoli-test-helper');
 const createBuilder = BroccoliTestHelper.createBuilder;
 const createTempDir = BroccoliTestHelper.createTempDir;
+const terminateWorkerPool = require('./utils/terminate-workers');
 
 let Addon = CoreObject.extend(AddonMixin);
 
@@ -50,6 +51,8 @@ describe('ember-cli-babel', function() {
     afterEach(co.wrap(function* () {
       yield input.dispose();
       yield output.dispose();
+      // shut down workers after the tests are run so that mocha doesn't hang
+      yield terminateWorkerPool();
     }));
 
     it("should build", co.wrap(function* () {

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -17,6 +17,7 @@ const terminateWorkerPool = require('./utils/terminate-workers');
 let Addon = CoreObject.extend(AddonMixin);
 
 describe('ember-cli-babel', function() {
+
   const ORIGINAL_EMBER_ENV = process.env.EMBER_ENV;
 
   beforeEach(function() {
@@ -820,6 +821,8 @@ describe('ember-cli-babel', function() {
   });
 
   describe('_getPresetEnvPlugins', function() {
+    this.timeout(5000);
+
     function includesPlugin(haystack, needleName) {
       let presetEnvBaseDir = path.dirname(require.resolve('babel-preset-env'));
       let pluginPath = resolve.sync(needleName, { basedir: presetEnvBaseDir });

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -859,9 +859,9 @@ describe('ember-cli-babel', function() {
       };
 
       let invokingOptions;
-      this.addon._presetEnv = function(context, options) {
+      this.addon._presetEnv = function(options) {
         invokingOptions = options;
-        return { plugins: [] };
+        return [];
       };
 
       this.addon.buildBabelOptions();
@@ -878,9 +878,9 @@ describe('ember-cli-babel', function() {
       };
 
       let invokingOptions;
-      this.addon._presetEnv = function(context, options) {
+      this.addon._presetEnv = function(options) {
         invokingOptions = options;
-        return { plugins: [] };
+        return [];
       };
 
       this.addon.buildBabelOptions();
@@ -893,18 +893,38 @@ describe('ember-cli-babel', function() {
         browsers: ['ie 9']
       };
 
-      let plugins = this.addon.buildBabelOptions().plugins;
+      let invokingOptions;
+      let presetEnvOrig = this.addon._presetEnv;
+      this.addon._presetEnv = function(options) {
+        invokingOptions = options;
+        return presetEnvOrig(options);
+      };
+      this.addon.buildBabelOptions();
+      this.addon._presetEnv = presetEnvOrig;
+
+      const presetEnv = require('babel-preset-env').default;
+      let plugins = presetEnv(null, invokingOptions).plugins;
       let found = includesPlugin(plugins, 'babel-plugin-transform-es2015-classes');
 
       expect(found).to.be.true;
     });
 
-    it('returns false when targets do not require plugin', function() {
+    it('does not include class transform when targets do not require plugin', function() {
       this.addon.project.targets = {
         browsers: ['last 2 chrome versions']
       };
 
-      let plugins = this.addon.buildBabelOptions().plugins;
+      let invokingOptions;
+      let presetEnvOrig = this.addon._presetEnv;
+      this.addon._presetEnv = function(options) {
+        invokingOptions = options;
+        return presetEnvOrig(options);
+      };
+      this.addon.buildBabelOptions();
+      this.addon._presetEnv = presetEnvOrig;
+
+      const presetEnv = require('babel-preset-env').default;
+      let plugins = presetEnv(null, invokingOptions).plugins;
       let found = includesPlugin(plugins, 'babel-plugin-transform-es2015-classes');
 
       expect(found).to.be.false;

--- a/node-tests/utils/terminate-workers.js
+++ b/node-tests/utils/terminate-workers.js
@@ -1,0 +1,19 @@
+'use strict';
+
+let ParallelApi = require('broccoli-babel-transpiler/lib/parallel-api');
+
+module.exports = function terminateWorkerPool() {
+  // shut down any workerpool that is running at this point
+  let babelCoreVersion = ParallelApi.getBabelVersion();
+  let workerPoolId = 'v1/broccoli-babel-transpiler/workerpool/babel-core-' + babelCoreVersion;
+  let runningPool = process[workerPoolId];
+
+  if (runningPool) {
+    return runningPool.terminate()
+      .then(() => {
+        delete process[workerPoolId];
+      });
+  } else {
+    return Promise.resolve();
+  }
+};


### PR DESCRIPTION
This is a working version of https://github.com/babel/ember-cli-babel/pull/218, to enable parallel transpilation with the default configuration.

This adds the use of `require.resolve` to enable multiple independent versions of ember-cli-babel to coexist, and fixes the tests to account for the changes.

