### PR TITLE
Fix presets array bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ module.exports = {
 
     options.presets = [
       shouldRunPresetEnv && this._getPresetEnvPlugins(addonProvidedConfig),
-    ]
+    ].filter(Boolean);
 
     if (shouldCompileModules) {
       options.moduleIds = true;

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -791,6 +791,24 @@ describe('ember-cli-babel', function() {
       expect(result.plugins).to.deep.include(plugin);
     });
 
+    it('sets `presets` to empty array if `disablePresetEnv` is true', function() {
+      let options = {
+        'ember-cli-babel': {
+          disablePresetEnv: true,
+        }
+      };
+      this.addon.parent = {
+        options: {
+          babel6: {
+            plugins: [ {} ]
+          },
+        },
+      };
+
+      let result = this.addon.buildBabelOptions(options);
+      expect(result.presets).to.deep.equal([]);
+    });
+
     it('user plugins are before preset-env plugins', function() {
       let plugin = function Plugin() {};
       this.addon.parent = {


### PR DESCRIPTION
In `ember-cli` when using `DELAYED_TRANSPILATION` feature, we explicitly
set `disablePresetEnv` flag to `true`. `shouldRunPresetEnv` is a
negation of `disablePresetEnv`.

Prior to this change `options.presets` was an array with one `false`
item in it (`shouldRunPresetEnv` was set to `false`) and would not let files
be transplied when `DELAYED_TRANSPILATION` was enabled.

Useful links:

+ https://github.com/ember-cli/ember-cli/blob/2e0cade64c4698cc48b1fdc20fda2219e63cc973/lib/models/addon.js#L256