### PR TITLE
Handle Windows paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const VersionChecker = require('ember-cli-version-checker');
 const clone = require('clone');
 const path = require('path');
 const semver = require('semver');
+const ensurePosixPath = require('ensure-posix-path');
 
 // From https://github.com/babel/babel-preset-env/tree/v1.6.1#options (linked from our README)
 const PRESET_ENV_OPTIONS = ['spec', 'loose', 'modules', 'debug', 'include', 'exclude', 'useBuiltIns'];
@@ -224,7 +225,7 @@ module.exports = {
 
     if (shouldCompileModules) {
       options.moduleIds = true;
-      options.getModuleId = getRelativeModulePath;
+      options.getModuleId = modulePath => ensurePosixPath(getRelativeModulePath(modulePath));
     }
 
     options.highlightCode = false;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "broccoli-source": "^1.1.0",
     "clone": "^2.0.0",
     "ember-cli-version-checker": "^2.1.0",
+    "ensure-posix-path": "^1.0.2",
     "semver": "^5.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Followup to #234 — don't want `define('dummy\\app', ...)` on Windows.