### PR TITLE
feat: make processed file extensions configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ interface EmberCLIBabelConfig {
     disableDebugTooling?: boolean;
     disablePresetEnv?: boolean;
     disableEmberModulesAPIPolyfill?: boolean;
+    extensions?: string[];
   };
 }
 ```

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = {
   setupPreprocessorRegistry(type, registry) {
     registry.add('js', {
       name: 'ember-cli-babel',
-      ext: 'js',
+      ext: this._getExtensions(this._getAddonOptions()),
       toTree: (tree) => this.transpileTree(tree)
     });
   },
@@ -150,6 +150,11 @@ module.exports = {
     };
   },
 
+  _getExtensions(config) {
+    let emberCLIBabelConfig = config['ember-cli-babel'] || {};
+    return emberCLIBabelConfig.extensions || ['js'];
+  },
+
   _getBabelOptions(config) {
     let addonProvidedConfig = this._getAddonProvidedConfig(config);
     let shouldCompileModules = this._shouldCompileModules(config);
@@ -170,10 +175,13 @@ module.exports = {
       sourceMaps = config.babel.sourceMaps;
     }
 
+    let filterExtensions = this._getExtensions(config);
+
     let options = {
       annotation: providedAnnotation || `Babel: ${this._parentName()}`,
       sourceMaps,
-      throwUnlessParallelizable
+      throwUnlessParallelizable,
+      filterExtensions
     };
 
     let userPlugins = addonProvidedConfig.plugins;


### PR DESCRIPTION
This adds an optional `extensions` property to the `ember-cli-babel` config hash and allows users to process files that don't end in `.js`.

For instance:

```js
  let app = new EmberApp(defaults, {
    'ember-cli-babel': {
      extensions: ['js', 'ts']
    },
    babel: {
      plugins: [
        '@babel/transform-typescript',
        '@babel/proposal-class-properties',
        '@babel/proposal-object-rest-spread'
      ]
    }
  });
```

I branched off of `v7.0.0-beta.3`, because the latest commit bricked the `package.json` by referring to a package on the file system. I'll rebase, when this is fixed.