### PR TITLE
fix: require @babel/preset-env instead of babel-preset-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ interface EmberCLIBabelConfig {
     disableDebugTooling?: boolean;
     disablePresetEnv?: boolean;
     disableEmberModulesAPIPolyfill?: boolean;
+    extensions?: string[];
   };
 }
 ```

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = {
   setupPreprocessorRegistry(type, registry) {
     registry.add('js', {
       name: 'ember-cli-babel',
-      ext: 'js',
+      ext: this._getExtensions(this._getAddonOptions()),
       toTree: (tree) => this.transpileTree(tree)
     });
   },
@@ -177,6 +177,11 @@ module.exports = {
     };
   },
 
+  _getExtensions(config) {
+    let emberCLIBabelConfig = config['ember-cli-babel'] || {};
+    return emberCLIBabelConfig.extensions || ['js'];
+  },
+
   _getBabelOptions(config) {
     let addonProvidedConfig = this._getAddonProvidedConfig(config);
     let shouldCompileModules = this._shouldCompileModules(config);
@@ -197,10 +202,13 @@ module.exports = {
       sourceMaps = config.babel.sourceMaps;
     }
 
+    let filterExtensions = this._getExtensions(config);
+
     let options = {
       annotation: providedAnnotation || `Babel: ${this._parentName()}`,
       sourceMaps,
-      throwUnlessParallelizable
+      throwUnlessParallelizable,
+      filterExtensions
     };
 
     let userPlugins = addonProvidedConfig.plugins;

--- a/index.js
+++ b/index.js
@@ -300,7 +300,7 @@ module.exports = {
   },
 
   _presetEnv(presetOptions) {
-    return [require.resolve('babel-preset-env'), presetOptions];
+    return [require.resolve('@babel/preset-env'), presetOptions];
   },
 
   _getTargets() {

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -831,7 +831,7 @@ describe('ember-cli-babel', function() {
       this.addon.buildBabelOptions();
       this.addon._presetEnv = presetEnvOrig;
 
-      const presetEnv = require('babel-preset-env').default;
+      const presetEnv = require('@babel/preset-env').default;
       let plugins = presetEnv(null, invokingOptions).plugins;
       let found = includesPlugin(plugins, '@babel/plugin-transform-classes');
 
@@ -852,7 +852,7 @@ describe('ember-cli-babel', function() {
       this.addon.buildBabelOptions();
       this.addon._presetEnv = presetEnvOrig;
 
-      const presetEnv = require('babel-preset-env').default;
+      const presetEnv = require('@babel/preset-env').default;
       let plugins = presetEnv(null, invokingOptions).plugins;
       let found = includesPlugin(plugins, 'babel-plugin-transform-es2015-classes');
 

--- a/package.json
+++ b/package.json
@@ -37,15 +37,15 @@
     "test:all": "mocha node-tests && ember try:each"
   },
   "dependencies": {
-    "@babel/plugin-transform-modules-amd": "^7.0.0-beta.55",
-    "@babel/preset-env": "^7.0.0-beta.55",
+    "@babel/plugin-transform-modules-amd": "^7.0.0-beta.56",
+    "@babel/preset-env": "^7.0.0-beta.56",
     "amd-name-resolver": "1.2.0",
     "babel-plugin-debug-macros": "^0.2.0-beta.6",
+    "babel-plugin-ember-modules-api-polyfill": "^2.3.2",
     "babel-plugin-module-resolver": "^3.1.1",
     "babel-polyfill": "^7.0.0-beta.0",
     "broccoli-babel-transpiler": "github:babel/broccoli-babel-transpiler#babel-7",
     "broccoli-debug": "^0.6.4",
-    "babel-plugin-ember-modules-api-polyfill": "^2.3.2",
     "broccoli-funnel": "^2.0.0",
     "broccoli-source": "^1.1.0",
     "clone": "^2.0.0",
@@ -54,6 +54,7 @@
     "semver": "^5.5.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0-beta.56",
     "broccoli-test-helper": "^1.3.0",
     "chai": "^4.1.2",
     "co": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,6 +8,12 @@
   dependencies:
     "@babel/highlight" "7.0.0-beta.55"
 
+"@babel/code-frame@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.56.tgz#09f76300673ac085d3b90e02aafa0ffc2c96846a"
+  dependencies:
+    "@babel/highlight" "7.0.0-beta.56"
+
 "@babel/core@^7.0.0-beta.44":
   version "7.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0-beta.55.tgz#9e17c34b5ac855e427c98f570915a17fcc6bab4a"
@@ -27,6 +33,25 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0-beta.56.tgz#cc03ffbb62564fef58fd1cefcbb3e32011c21df9"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.56"
+    "@babel/generator" "7.0.0-beta.56"
+    "@babel/helpers" "7.0.0-beta.56"
+    "@babel/parser" "7.0.0-beta.56"
+    "@babel/template" "7.0.0-beta.56"
+    "@babel/traverse" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
+    convert-source-map "^1.1.0"
+    debug "^3.1.0"
+    json5 "^0.5.0"
+    lodash "^4.17.10"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@7.0.0-beta.55":
   version "7.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.55.tgz#8ec11152dcc398bae35dd181122704415c383a01"
@@ -37,41 +62,51 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/helper-annotate-as-pure@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.55.tgz#3c3e4c00e14e7dea917938e35ed5d9156cdd35ce"
+"@babel/generator@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.56.tgz#07d9c2f45990c453130e080eddcd252a9cbd8d66"
   dependencies:
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/types" "7.0.0-beta.56"
+    jsesc "^2.5.1"
+    lodash "^4.17.10"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
 
-"@babel/helper-builder-binary-assignment-operator-visitor@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.55.tgz#4d02128acff5c368a2d43ea8608260ce49aeec5d"
+"@babel/helper-annotate-as-pure@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.56.tgz#3814bfda01ec19f7daac810cc2375932a79acbbc"
   dependencies:
-    "@babel/helper-explode-assignable-expression" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/helper-call-delegate@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.55.tgz#13f68c85c2adfe87c02f7ab4d2a63d35cd67d724"
+"@babel/helper-builder-binary-assignment-operator-visitor@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.56.tgz#c80d0edb162eb91d44dd5b25c5083cf6d72d7088"
   dependencies:
-    "@babel/helper-hoist-variables" "7.0.0-beta.55"
-    "@babel/traverse" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/helper-explode-assignable-expression" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/helper-define-map@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.55.tgz#b62bcb37b753be416db7f21563f0162cd933403a"
+"@babel/helper-call-delegate@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.56.tgz#eacdf2f2943be79dfe259011ee8362cd61012acd"
   dependencies:
-    "@babel/helper-function-name" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/helper-hoist-variables" "7.0.0-beta.56"
+    "@babel/traverse" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
+
+"@babel/helper-define-map@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.56.tgz#2c3d0a584843c2d6fc555f8f80e335eddc34ec38"
+  dependencies:
+    "@babel/helper-function-name" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
     lodash "^4.17.10"
 
-"@babel/helper-explode-assignable-expression@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.55.tgz#f5c096f261ca4efc6154b2633317eec1ed9029ea"
+"@babel/helper-explode-assignable-expression@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.56.tgz#3e21d74e8d46e591dc305c70824561a80d0a53d2"
   dependencies:
-    "@babel/traverse" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/traverse" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
 
 "@babel/helper-function-name@7.0.0-beta.55":
   version "7.0.0-beta.55"
@@ -81,83 +116,97 @@
     "@babel/template" "7.0.0-beta.55"
     "@babel/types" "7.0.0-beta.55"
 
+"@babel/helper-function-name@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.56.tgz#4e9c8a84ce4368b4a779409d0c4fe3f714be60ab"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.56"
+    "@babel/template" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
+
 "@babel/helper-get-function-arity@7.0.0-beta.55":
   version "7.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.55.tgz#8559ded96ecd3b626f9c1f57494edc4fa3cc6a94"
   dependencies:
     "@babel/types" "7.0.0-beta.55"
 
-"@babel/helper-hoist-variables@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.55.tgz#a88c5d992dca109199cf95b25907534a959dc461"
+"@babel/helper-get-function-arity@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.56.tgz#872864d67e25705b94d1c71afc72344aafc8dc9c"
   dependencies:
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/helper-member-expression-to-functions@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.55.tgz#823d254bc9bd019a529fe2ab7f9e1d26870c5e50"
+"@babel/helper-hoist-variables@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.56.tgz#6d32ac403a51b0a19e2144820d53a793a04df263"
   dependencies:
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/helper-module-imports@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.55.tgz#93f927c6631d0689b8bbd1991d3fb2aa63eeb3f2"
+"@babel/helper-member-expression-to-functions@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.56.tgz#f7d8d673e140c1bf051abf9661652788ae37b1b4"
   dependencies:
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/types" "7.0.0-beta.56"
+
+"@babel/helper-module-imports@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.56.tgz#edf9494ef1f36674bb19cec9ea142b70f186406d"
+  dependencies:
+    "@babel/types" "7.0.0-beta.56"
     lodash "^4.17.10"
 
-"@babel/helper-module-transforms@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.55.tgz#2bd12f0e9187e5d69599ffa7c11fe9a3a67b03d2"
+"@babel/helper-module-transforms@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.56.tgz#327ba3bd62bcfa597b008f48c0826cdc690ba944"
   dependencies:
-    "@babel/helper-module-imports" "7.0.0-beta.55"
-    "@babel/helper-simple-access" "7.0.0-beta.55"
-    "@babel/helper-split-export-declaration" "7.0.0-beta.55"
-    "@babel/template" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/helper-module-imports" "7.0.0-beta.56"
+    "@babel/helper-simple-access" "7.0.0-beta.56"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.56"
+    "@babel/template" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
     lodash "^4.17.10"
 
-"@babel/helper-optimise-call-expression@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.55.tgz#57fdc6898bc53f02da78bf4a39509d4dfc3b33cb"
+"@babel/helper-optimise-call-expression@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.56.tgz#e9814da0d175ca39901f2d895d6dfef658fe8953"
   dependencies:
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/helper-plugin-utils@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.55.tgz#31f40777efd6b961da8496a923c22d2b062b3f73"
+"@babel/helper-plugin-utils@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz#e5f63cae8b3b716825d64e69ad8b59d71cd2080c"
 
-"@babel/helper-regex@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0-beta.55.tgz#74e6c063d1ef9f7e58b7a84c06e6ee4a5bb5a5da"
+"@babel/helper-regex@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0-beta.56.tgz#88d8a15c853892f603193e5adf10c428cd588fc0"
   dependencies:
     lodash "^4.17.10"
 
-"@babel/helper-remap-async-to-generator@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.55.tgz#e762d1b8f7f06121ed3e40befb1f9847d4658a7d"
+"@babel/helper-remap-async-to-generator@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.56.tgz#e5c8958f324395c16606b85ecdf4de1335eaa541"
   dependencies:
-    "@babel/helper-annotate-as-pure" "7.0.0-beta.55"
-    "@babel/helper-wrap-function" "7.0.0-beta.55"
-    "@babel/template" "7.0.0-beta.55"
-    "@babel/traverse" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/helper-annotate-as-pure" "7.0.0-beta.56"
+    "@babel/helper-wrap-function" "7.0.0-beta.56"
+    "@babel/template" "7.0.0-beta.56"
+    "@babel/traverse" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/helper-replace-supers@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.55.tgz#d588ad863990f35d8b0f67aa94ef8eec24171855"
+"@babel/helper-replace-supers@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.56.tgz#52f25c16b3dee1f4e8cd96eb4d1d7f9af9db18d8"
   dependencies:
-    "@babel/helper-member-expression-to-functions" "7.0.0-beta.55"
-    "@babel/helper-optimise-call-expression" "7.0.0-beta.55"
-    "@babel/traverse" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/helper-member-expression-to-functions" "7.0.0-beta.56"
+    "@babel/helper-optimise-call-expression" "7.0.0-beta.56"
+    "@babel/traverse" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
 
-"@babel/helper-simple-access@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.55.tgz#f3f3ce279f20fc90c166c4fea1667646857ba559"
+"@babel/helper-simple-access@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.56.tgz#bb6569e0ada73f408ca6e00514f9ca2c02970c0d"
   dependencies:
-    "@babel/template" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/template" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
     lodash "^4.17.10"
 
 "@babel/helper-split-export-declaration@7.0.0-beta.55":
@@ -166,14 +215,20 @@
   dependencies:
     "@babel/types" "7.0.0-beta.55"
 
-"@babel/helper-wrap-function@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.55.tgz#3053e77647057b29b88d9625503e033b1bd349b4"
+"@babel/helper-split-export-declaration@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.56.tgz#82d53382836134ba3ed0ea2394ca21fe579ec241"
   dependencies:
-    "@babel/helper-function-name" "7.0.0-beta.55"
-    "@babel/template" "7.0.0-beta.55"
-    "@babel/traverse" "7.0.0-beta.55"
-    "@babel/types" "7.0.0-beta.55"
+    "@babel/types" "7.0.0-beta.56"
+
+"@babel/helper-wrap-function@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.56.tgz#e493eff444f161569c2c0091a7bd60670fc03d8d"
+  dependencies:
+    "@babel/helper-function-name" "7.0.0-beta.56"
+    "@babel/template" "7.0.0-beta.56"
+    "@babel/traverse" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
 
 "@babel/helpers@7.0.0-beta.55":
   version "7.0.0-beta.55"
@@ -183,9 +238,25 @@
     "@babel/traverse" "7.0.0-beta.55"
     "@babel/types" "7.0.0-beta.55"
 
+"@babel/helpers@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.0.0-beta.56.tgz#a01cac1481c6fa38197ae410137539045b160443"
+  dependencies:
+    "@babel/template" "7.0.0-beta.56"
+    "@babel/traverse" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
+
 "@babel/highlight@7.0.0-beta.55":
   version "7.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.55.tgz#988653647d629c261dae156e74d5f0252ba520c0"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/highlight@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.56.tgz#f8b0fc8c5c2de53bb2c12f9001ad3d99e573696d"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
@@ -195,282 +266,286 @@
   version "7.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.55.tgz#0a527efc148c6c8cd85d5ffddacad817a2daeeb2"
 
-"@babel/plugin-proposal-async-generator-functions@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.55.tgz#512bb28c0401769811818d6b4453ce9bdf5f21ca"
-  dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
-    "@babel/helper-remap-async-to-generator" "7.0.0-beta.55"
-    "@babel/plugin-syntax-async-generators" "7.0.0-beta.55"
+"@babel/parser@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.56.tgz#8638aa02e0130cd10b2ba4128e2b804112073ed3"
 
-"@babel/plugin-proposal-object-rest-spread@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.55.tgz#b611bb83901bf05196237c516a8bb1117a2a9396"
+"@babel/plugin-proposal-async-generator-functions@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.56.tgz#078b8763a7423c99dfb7af8906966fc6b667dfb1"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
-    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
+    "@babel/helper-remap-async-to-generator" "7.0.0-beta.56"
+    "@babel/plugin-syntax-async-generators" "7.0.0-beta.56"
 
-"@babel/plugin-proposal-optional-catch-binding@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.55.tgz#365727b214a3e3e5cbeb92c471635a5f51839735"
+"@babel/plugin-proposal-object-rest-spread@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.56.tgz#5a8b8c89e94155d766baacdf8e50ea7dead96741"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
-    "@babel/plugin-syntax-optional-catch-binding" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
+    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.56"
 
-"@babel/plugin-proposal-unicode-property-regex@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.55.tgz#987f851d4f50fbb91c17ba51cc113d8d3f558c5b"
+"@babel/plugin-proposal-optional-catch-binding@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.56.tgz#0b0afe131ba4b42f0961435cfec0f4d5525fe06c"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
-    "@babel/helper-regex" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
+    "@babel/plugin-syntax-optional-catch-binding" "7.0.0-beta.56"
+
+"@babel/plugin-proposal-unicode-property-regex@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.56.tgz#df00a82966ebaf2ddd3a7fee8f746dbbf0013956"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
+    "@babel/helper-regex" "7.0.0-beta.56"
     regexpu-core "^4.2.0"
 
-"@babel/plugin-syntax-async-generators@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.55.tgz#e72b3857eb80b695c77c3721237b149072cda46b"
+"@babel/plugin-syntax-async-generators@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.56.tgz#e784a9f104fa9df3a6273079a8be7ef5085259ea"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-syntax-object-rest-spread@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.55.tgz#990ea47e790d7d9a9d28469c6bcc15f580bf19e9"
+"@babel/plugin-syntax-object-rest-spread@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.56.tgz#ebcb1406eaadb1307df02b2ebbc91fd069729f73"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-syntax-optional-catch-binding@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.55.tgz#ef903fee2dbc3621773d7db2dec9861c8f976c12"
+"@babel/plugin-syntax-optional-catch-binding@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.56.tgz#3606e382384507b71adaf2f2f239395c5695ec2c"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-arrow-functions@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.55.tgz#eacb446ffc67e5135a4a29ac72bffac1ada181f6"
+"@babel/plugin-transform-arrow-functions@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.56.tgz#b547c40003f6795a824c3af501dc963acc6b2492"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-async-to-generator@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.55.tgz#490a4715540807bd89f5858e8aac30d1561bdd65"
+"@babel/plugin-transform-async-to-generator@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.56.tgz#1ce419953fc3c4364ab95442653e4bd460815ed3"
   dependencies:
-    "@babel/helper-module-imports" "7.0.0-beta.55"
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
-    "@babel/helper-remap-async-to-generator" "7.0.0-beta.55"
+    "@babel/helper-module-imports" "7.0.0-beta.56"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
+    "@babel/helper-remap-async-to-generator" "7.0.0-beta.56"
 
-"@babel/plugin-transform-block-scoped-functions@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.55.tgz#0670d0a149435eea73f72e3392a51b38de607270"
+"@babel/plugin-transform-block-scoped-functions@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.56.tgz#ad6fe88ef1b1d5c6f301a13e5185942e963202c3"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-block-scoping@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.55.tgz#c826f8c20304ac39f6cdd11d14f1cd7d90aa5470"
+"@babel/plugin-transform-block-scoping@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.56.tgz#b4a3ec153d19b92680db95f4c3823b88e6f93197"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
     lodash "^4.17.10"
 
-"@babel/plugin-transform-classes@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.55.tgz#fa260266943f7a1e144ef9783d9a07e987755022"
+"@babel/plugin-transform-classes@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.56.tgz#99b405dee3fb466c09c1e0874e795f4682ee690d"
   dependencies:
-    "@babel/helper-annotate-as-pure" "7.0.0-beta.55"
-    "@babel/helper-define-map" "7.0.0-beta.55"
-    "@babel/helper-function-name" "7.0.0-beta.55"
-    "@babel/helper-optimise-call-expression" "7.0.0-beta.55"
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
-    "@babel/helper-replace-supers" "7.0.0-beta.55"
-    "@babel/helper-split-export-declaration" "7.0.0-beta.55"
+    "@babel/helper-annotate-as-pure" "7.0.0-beta.56"
+    "@babel/helper-define-map" "7.0.0-beta.56"
+    "@babel/helper-function-name" "7.0.0-beta.56"
+    "@babel/helper-optimise-call-expression" "7.0.0-beta.56"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
+    "@babel/helper-replace-supers" "7.0.0-beta.56"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.56"
     globals "^11.1.0"
 
-"@babel/plugin-transform-computed-properties@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.55.tgz#a04f101f305695031ffda61501728c00180237b9"
+"@babel/plugin-transform-computed-properties@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.56.tgz#774e705279d5ca3bdb132d93b6a7fc046a660608"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-destructuring@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.55.tgz#1d44216cbbdb5d873819abb71fe033c14a1c1723"
+"@babel/plugin-transform-destructuring@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.56.tgz#41ab43ad5a885b73cc44192948109076a95c2bf0"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-dotall-regex@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.55.tgz#2b9c2d13b79b660789b40f9f49873525d7d77437"
+"@babel/plugin-transform-dotall-regex@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.56.tgz#f8586e81e4d5f6609f1b7be0dcbce77a2bd3bd24"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
-    "@babel/helper-regex" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
+    "@babel/helper-regex" "7.0.0-beta.56"
     regexpu-core "^4.1.3"
 
-"@babel/plugin-transform-duplicate-keys@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.55.tgz#d1300c60703d5b5205f65ea178b7b5715d0b9687"
+"@babel/plugin-transform-duplicate-keys@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.56.tgz#8217b5a3c3ef078009e64989b0c6bdb3a5ad9960"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-exponentiation-operator@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.55.tgz#ddcac0ea80e6641681a473a703093cd2f623a59e"
+"@babel/plugin-transform-exponentiation-operator@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.56.tgz#da1c786c70af6249d142771d408dc1abb2fb8871"
   dependencies:
-    "@babel/helper-builder-binary-assignment-operator-visitor" "7.0.0-beta.55"
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-builder-binary-assignment-operator-visitor" "7.0.0-beta.56"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-for-of@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.55.tgz#cf3058c6d81a3d69e5df086294688dac28a42710"
+"@babel/plugin-transform-for-of@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.56.tgz#a95335820f8dedf30b96ec03e4cac09a5bb4edf2"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-function-name@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.55.tgz#114384d56e1739492bd4ce9337dd158acde14801"
+"@babel/plugin-transform-function-name@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.56.tgz#7382a1cc8df0d8b04be36d83773dd6b451ddd045"
   dependencies:
-    "@babel/helper-function-name" "7.0.0-beta.55"
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-function-name" "7.0.0-beta.56"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-literals@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.55.tgz#8bc92cd24e6419301ef3867e4667b77aa6374e11"
+"@babel/plugin-transform-literals@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.56.tgz#5f6d3d0dad64c52df64fe8654a8e6d6fd884d60f"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-modules-amd@7.0.0-beta.55", "@babel/plugin-transform-modules-amd@^7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.55.tgz#c8b59b84d6f4987512667c6f9410af3ddd562e12"
+"@babel/plugin-transform-modules-amd@7.0.0-beta.56", "@babel/plugin-transform-modules-amd@^7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.56.tgz#000ae2a3f41a9dd43d55211df3fcc74ac8e17418"
   dependencies:
-    "@babel/helper-module-transforms" "7.0.0-beta.55"
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-module-transforms" "7.0.0-beta.56"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-modules-commonjs@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.55.tgz#748af5037e28a78694df71be2e8d02c5c84b8aaf"
+"@babel/plugin-transform-modules-commonjs@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.56.tgz#d0c96de58d11c032d9098b891b25874a387f496c"
   dependencies:
-    "@babel/helper-module-transforms" "7.0.0-beta.55"
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
-    "@babel/helper-simple-access" "7.0.0-beta.55"
+    "@babel/helper-module-transforms" "7.0.0-beta.56"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
+    "@babel/helper-simple-access" "7.0.0-beta.56"
 
-"@babel/plugin-transform-modules-systemjs@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.55.tgz#9e36a7d48c9137781484c5442da426873289594e"
+"@babel/plugin-transform-modules-systemjs@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.56.tgz#7aecc2a886a151aabfe86e5c01811f5cf9c27d04"
   dependencies:
-    "@babel/helper-hoist-variables" "7.0.0-beta.55"
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-hoist-variables" "7.0.0-beta.56"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-modules-umd@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.55.tgz#028c96f64e89313657c6d5f5ff0660fc99f6ee0a"
+"@babel/plugin-transform-modules-umd@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.56.tgz#1dd72699fd8fbafda4c259318771d97f91cd8410"
   dependencies:
-    "@babel/helper-module-transforms" "7.0.0-beta.55"
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-module-transforms" "7.0.0-beta.56"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-new-target@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.55.tgz#0164ad758b68f67fc39dbef1b7d61e37f5a9bfd5"
+"@babel/plugin-transform-new-target@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.56.tgz#a8b219cece600e57cdc372b8a41c21e01f8165d8"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-object-super@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.55.tgz#b518d13a90352128191514d7d5db8e5a78c9992b"
+"@babel/plugin-transform-object-super@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.56.tgz#b02d5d99aeffd9770e2a5de95260bf720f90ebab"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
-    "@babel/helper-replace-supers" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
+    "@babel/helper-replace-supers" "7.0.0-beta.56"
 
-"@babel/plugin-transform-parameters@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.55.tgz#f211f18a560a4d928d9649da11c28dd89f15effe"
+"@babel/plugin-transform-parameters@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.56.tgz#9010f8743e8bb213e14c1fe9f801588e509f46b1"
   dependencies:
-    "@babel/helper-call-delegate" "7.0.0-beta.55"
-    "@babel/helper-get-function-arity" "7.0.0-beta.55"
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-call-delegate" "7.0.0-beta.56"
+    "@babel/helper-get-function-arity" "7.0.0-beta.56"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-regenerator@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.55.tgz#a12ba1376c647cf0b777dea8a7b55fe4665ed1ff"
+"@babel/plugin-transform-regenerator@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.56.tgz#03999df0a27e5cc38686d90e83be0190660f3960"
   dependencies:
     regenerator-transform "^0.13.3"
 
-"@babel/plugin-transform-shorthand-properties@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.55.tgz#75e97575b87c6fe31c008fc3d755fddcd6cb908a"
+"@babel/plugin-transform-shorthand-properties@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.56.tgz#bf78900f016774a28d56ec8e83d0cec4d662b7ff"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-spread@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.55.tgz#d5a1c320aac86469d6d311e136a89fb5a1f65600"
+"@babel/plugin-transform-spread@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.56.tgz#a8681e7d78b648b7170a211068bea31aaedf0ea2"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-sticky-regex@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.55.tgz#d0b80b2deb8b4db03bc6459ebe79ad8b39b40546"
+"@babel/plugin-transform-sticky-regex@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.56.tgz#89b37d31fac03f0c87b99dd7b190159d098f7398"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
-    "@babel/helper-regex" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
+    "@babel/helper-regex" "7.0.0-beta.56"
 
-"@babel/plugin-transform-template-literals@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.55.tgz#b00a6496d4c8384507559598aaf49d8c1ad892e6"
+"@babel/plugin-transform-template-literals@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.56.tgz#2ddc47b1b26f60bf8d755d71d4b8e1440ebad2c7"
   dependencies:
-    "@babel/helper-annotate-as-pure" "7.0.0-beta.55"
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-annotate-as-pure" "7.0.0-beta.56"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-typeof-symbol@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.55.tgz#62326918560b765bbe9f362ad3a4ce3bc71477bc"
+"@babel/plugin-transform-typeof-symbol@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.56.tgz#76160d2bfee43b7d4ea07cf3c51dd7fa6578f8ec"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
 
-"@babel/plugin-transform-unicode-regex@7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.55.tgz#87e7bedbba103f784a7999f82064f47c0b35c796"
+"@babel/plugin-transform-unicode-regex@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.56.tgz#b3fad34e9c5a6d4181af443713d9e38a292c8bb0"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
-    "@babel/helper-regex" "7.0.0-beta.55"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
+    "@babel/helper-regex" "7.0.0-beta.56"
     regexpu-core "^4.1.3"
 
-"@babel/preset-env@^7.0.0-beta.55":
-  version "7.0.0-beta.55"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.0.0-beta.55.tgz#d3d997517761890144081d53c0c669ba7e8334e0"
+"@babel/preset-env@^7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.0.0-beta.56.tgz#1d00bb1768c422b363be214c12f3b99dc5e4cc0c"
   dependencies:
-    "@babel/helper-module-imports" "7.0.0-beta.55"
-    "@babel/helper-plugin-utils" "7.0.0-beta.55"
-    "@babel/plugin-proposal-async-generator-functions" "7.0.0-beta.55"
-    "@babel/plugin-proposal-object-rest-spread" "7.0.0-beta.55"
-    "@babel/plugin-proposal-optional-catch-binding" "7.0.0-beta.55"
-    "@babel/plugin-proposal-unicode-property-regex" "7.0.0-beta.55"
-    "@babel/plugin-syntax-async-generators" "7.0.0-beta.55"
-    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.55"
-    "@babel/plugin-syntax-optional-catch-binding" "7.0.0-beta.55"
-    "@babel/plugin-transform-arrow-functions" "7.0.0-beta.55"
-    "@babel/plugin-transform-async-to-generator" "7.0.0-beta.55"
-    "@babel/plugin-transform-block-scoped-functions" "7.0.0-beta.55"
-    "@babel/plugin-transform-block-scoping" "7.0.0-beta.55"
-    "@babel/plugin-transform-classes" "7.0.0-beta.55"
-    "@babel/plugin-transform-computed-properties" "7.0.0-beta.55"
-    "@babel/plugin-transform-destructuring" "7.0.0-beta.55"
-    "@babel/plugin-transform-dotall-regex" "7.0.0-beta.55"
-    "@babel/plugin-transform-duplicate-keys" "7.0.0-beta.55"
-    "@babel/plugin-transform-exponentiation-operator" "7.0.0-beta.55"
-    "@babel/plugin-transform-for-of" "7.0.0-beta.55"
-    "@babel/plugin-transform-function-name" "7.0.0-beta.55"
-    "@babel/plugin-transform-literals" "7.0.0-beta.55"
-    "@babel/plugin-transform-modules-amd" "7.0.0-beta.55"
-    "@babel/plugin-transform-modules-commonjs" "7.0.0-beta.55"
-    "@babel/plugin-transform-modules-systemjs" "7.0.0-beta.55"
-    "@babel/plugin-transform-modules-umd" "7.0.0-beta.55"
-    "@babel/plugin-transform-new-target" "7.0.0-beta.55"
-    "@babel/plugin-transform-object-super" "7.0.0-beta.55"
-    "@babel/plugin-transform-parameters" "7.0.0-beta.55"
-    "@babel/plugin-transform-regenerator" "7.0.0-beta.55"
-    "@babel/plugin-transform-shorthand-properties" "7.0.0-beta.55"
-    "@babel/plugin-transform-spread" "7.0.0-beta.55"
-    "@babel/plugin-transform-sticky-regex" "7.0.0-beta.55"
-    "@babel/plugin-transform-template-literals" "7.0.0-beta.55"
-    "@babel/plugin-transform-typeof-symbol" "7.0.0-beta.55"
-    "@babel/plugin-transform-unicode-regex" "7.0.0-beta.55"
+    "@babel/helper-module-imports" "7.0.0-beta.56"
+    "@babel/helper-plugin-utils" "7.0.0-beta.56"
+    "@babel/plugin-proposal-async-generator-functions" "7.0.0-beta.56"
+    "@babel/plugin-proposal-object-rest-spread" "7.0.0-beta.56"
+    "@babel/plugin-proposal-optional-catch-binding" "7.0.0-beta.56"
+    "@babel/plugin-proposal-unicode-property-regex" "7.0.0-beta.56"
+    "@babel/plugin-syntax-async-generators" "7.0.0-beta.56"
+    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.56"
+    "@babel/plugin-syntax-optional-catch-binding" "7.0.0-beta.56"
+    "@babel/plugin-transform-arrow-functions" "7.0.0-beta.56"
+    "@babel/plugin-transform-async-to-generator" "7.0.0-beta.56"
+    "@babel/plugin-transform-block-scoped-functions" "7.0.0-beta.56"
+    "@babel/plugin-transform-block-scoping" "7.0.0-beta.56"
+    "@babel/plugin-transform-classes" "7.0.0-beta.56"
+    "@babel/plugin-transform-computed-properties" "7.0.0-beta.56"
+    "@babel/plugin-transform-destructuring" "7.0.0-beta.56"
+    "@babel/plugin-transform-dotall-regex" "7.0.0-beta.56"
+    "@babel/plugin-transform-duplicate-keys" "7.0.0-beta.56"
+    "@babel/plugin-transform-exponentiation-operator" "7.0.0-beta.56"
+    "@babel/plugin-transform-for-of" "7.0.0-beta.56"
+    "@babel/plugin-transform-function-name" "7.0.0-beta.56"
+    "@babel/plugin-transform-literals" "7.0.0-beta.56"
+    "@babel/plugin-transform-modules-amd" "7.0.0-beta.56"
+    "@babel/plugin-transform-modules-commonjs" "7.0.0-beta.56"
+    "@babel/plugin-transform-modules-systemjs" "7.0.0-beta.56"
+    "@babel/plugin-transform-modules-umd" "7.0.0-beta.56"
+    "@babel/plugin-transform-new-target" "7.0.0-beta.56"
+    "@babel/plugin-transform-object-super" "7.0.0-beta.56"
+    "@babel/plugin-transform-parameters" "7.0.0-beta.56"
+    "@babel/plugin-transform-regenerator" "7.0.0-beta.56"
+    "@babel/plugin-transform-shorthand-properties" "7.0.0-beta.56"
+    "@babel/plugin-transform-spread" "7.0.0-beta.56"
+    "@babel/plugin-transform-sticky-regex" "7.0.0-beta.56"
+    "@babel/plugin-transform-template-literals" "7.0.0-beta.56"
+    "@babel/plugin-transform-typeof-symbol" "7.0.0-beta.56"
+    "@babel/plugin-transform-unicode-regex" "7.0.0-beta.56"
     browserslist "^3.0.0"
     invariant "^2.2.2"
     js-levenshtein "^1.1.3"
@@ -483,6 +558,15 @@
     "@babel/code-frame" "7.0.0-beta.55"
     "@babel/parser" "7.0.0-beta.55"
     "@babel/types" "7.0.0-beta.55"
+    lodash "^4.17.10"
+
+"@babel/template@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.56.tgz#a428197e0c9db142f8581cbfdcfa9289b0dd7fd7"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.56"
+    "@babel/parser" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
     lodash "^4.17.10"
 
 "@babel/traverse@7.0.0-beta.55":
@@ -499,9 +583,31 @@
     globals "^11.1.0"
     lodash "^4.17.10"
 
+"@babel/traverse@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.56.tgz#62fdfe69328cfaad414ef01844f5ab40e32f4ad0"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.56"
+    "@babel/generator" "7.0.0-beta.56"
+    "@babel/helper-function-name" "7.0.0-beta.56"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.56"
+    "@babel/parser" "7.0.0-beta.56"
+    "@babel/types" "7.0.0-beta.56"
+    debug "^3.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.10"
+
 "@babel/types@7.0.0-beta.55":
   version "7.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.55.tgz#7755c9d2e58315a64f05d8cf3322379be16d9199"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@7.0.0-beta.56":
+  version "7.0.0-beta.56"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.56.tgz#df456947a82510ec30361971e566110d89489056"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
@@ -1462,7 +1568,7 @@ broccoli-babel-transpiler@^6.0.0, broccoli-babel-transpiler@^6.4.5:
 
 "broccoli-babel-transpiler@github:babel/broccoli-babel-transpiler#babel-7":
   version "7.0.0-beta.3"
-  resolved "https://codeload.github.com/babel/broccoli-babel-transpiler/tar.gz/8b801cc061450b37fa5a8f4985e344d2d0088ce7"
+  resolved "https://codeload.github.com/babel/broccoli-babel-transpiler/tar.gz/95e2d735f50ca3b1a155e33ed112988b41c06fff"
   dependencies:
     "@babel/core" "^7.0.0-beta.44"
     broccoli-funnel "^2.0.1"


### PR DESCRIPTION
We're listing `@babel/preset-env` as a dependency and so should be using it. 😄 

This was the reason for transpilation failing on me for IE11, because some old incompatible transforms are used by `babel-preset-env`.

AFAICT I can now fully build our TypeScript app with _just_ ember-cli-babel. 😍 🎉 

Simple demo repo here: https://github.com/buschtoens/ember-typescript-babel-7

Thank you guys *so much*. ❤️ 

Closes #236, because it branched off of it.