### PR TITLE
Move `baseDir` definition into `relative-module-paths` module

### DIFF
--- a/index.js
+++ b/index.js
@@ -283,7 +283,6 @@ module.exports = {
 
   _getModulesPlugin() {
     const resolvePath = require('./lib/relative-module-paths').resolveRelativeModulePath;
-    resolvePath.baseDir = () => __dirname;
 
     return [
       [require.resolve('babel-plugin-module-resolver'), { resolvePath }],

--- a/lib/relative-module-paths.js
+++ b/lib/relative-module-paths.js
@@ -5,6 +5,8 @@ const path = require('path');
 const ensurePosix = require('ensure-posix-path');
 const { moduleResolve } = require('amd-name-resolver');
 
+const BASE_DIR = path.resolve(`${__dirname}/..`);
+
 function getRelativeModulePath(modulePath) {
   return ensurePosix(path.relative(process.cwd(), modulePath));
 }
@@ -19,6 +21,8 @@ module.exports = {
 };
 
 Object.keys(module.exports).forEach((key) => {
+  module.exports[key].baseDir = () => BASE_DIR;
+
   module.exports[key]._parallelBabel = {
     requireFile: __filename,
     useMethod: key


### PR DESCRIPTION
this will make it possible to reuse the `relative-module-paths` module in the build pipeline of Ember.js 