### PR TITLE
Update `@ember/string` detection to check if it is the project being run

### DIFF
--- a/index.js
+++ b/index.js
@@ -423,6 +423,7 @@ module.exports = {
         'fmt', 'loc', 'w',
         'decamelize', 'dasherize', 'camelize',
         'classify', 'underscore', 'capitalize',
+        'setStrings', 'getStrings', 'getString'
       ];
     }
 
@@ -430,6 +431,10 @@ module.exports = {
   },
 
   _emberStringDependencyPresent() {
+    if (this.project.name && this.project.name() === '@ember/string') {
+      return true;
+    }
+
     let checker = new VersionChecker(this.parent).for('@ember/string', 'npm');
 
     return checker.exists();


### PR DESCRIPTION
When running the tests for `@ember/string`, `ember-cli-babel` does not detect it properly and tries to process the imports for that module, leading to a failed test run.