### PR TITLE
Update to broccoli-babel-transpiler@7.1.2.

### DIFF
--- a/node-tests/utils/terminate-workers.js
+++ b/node-tests/utils/terminate-workers.js
@@ -5,7 +5,7 @@ let ParallelApi = require('broccoli-babel-transpiler/lib/parallel-api');
 module.exports = function terminateWorkerPool() {
   // shut down any workerpool that is running at this point
   let babelCoreVersion = ParallelApi.getBabelVersion();
-  let workerPoolId = 'v1/broccoli-babel-transpiler/workerpool/babel-core-' + babelCoreVersion;
+  let workerPoolId = 'v2/broccoli-babel-transpiler/workerpool/babel-core-' + babelCoreVersion;
   let runningPool = process[workerPoolId];
 
   if (runningPool) {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "babel-plugin-debug-macros": "^0.2.0-beta.6",
     "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
     "babel-plugin-module-resolver": "^3.1.1",
-    "broccoli-babel-transpiler": "^7.1.0",
+    "broccoli-babel-transpiler": "^7.1.2",
     "broccoli-debug": "^0.6.4",
     "broccoli-funnel": "^2.0.1",
     "broccoli-source": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,12 +1671,13 @@ broccoli-babel-transpiler@^6.0.0, broccoli-babel-transpiler@^6.5.0:
     rsvp "^4.8.2"
     workerpool "^2.3.0"
 
-broccoli-babel-transpiler@^7.1.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.1.1.tgz#4202cd0653845083ee744fb4eaa4a2b50292f03f"
-  integrity sha512-iZE6yxDcEe4XSMEyqyyS+wtkNAsPUGJNleJoVu26Vt2Al8/GqRI5+wc7qquPb71I1W7AtqbkaqsgDFDqBoIYKw==
+broccoli-babel-transpiler@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.1.2.tgz#fb5d6f8b9a805627ac3f2914ac9d86e82ca2413b"
+  integrity sha512-rljx86xgZJ2BjWt+xCSVfvyt3ONpCdMMXzMpeeVpAGdBHj3bqQICdPHZDAbzn1vKY/LIPsJZftvdxql1jiLGzw==
   dependencies:
     "@babel/core" "^7.0.0"
+    "@babel/polyfill" "^7.0.0"
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^3.0.0"
     broccoli-persistent-filter "^1.4.3"


### PR DESCRIPTION
Bumps the minimum version of broccoli-babel-transpiler to 7.1.2 which includes a few bug fixes. Also updates the test helpers to match the new global worker pool IDs.