### PR TITLE
Update babel-plugin-debug-macros

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/runtime": "^7.2.0",
     "amd-name-resolver": "^1.2.1",
-    "babel-plugin-debug-macros": "^0.2.0-beta.6",
+    "babel-plugin-debug-macros": "^0.3.0",
     "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
     "babel-plugin-module-resolver": "^3.1.1",
     "broccoli-babel-transpiler": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1130,6 +1130,13 @@ babel-plugin-debug-macros@^0.2.0-beta.6:
   dependencies:
     semver "^5.3.0"
 
+babel-plugin-debug-macros@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.0.tgz#7a025944faef0777804ef3518c54e8b040197397"
+  integrity sha512-D6qYBI/3+FvcKVnRnH6FBUwXPp/5o/jnJNVFKqVaZpYAWx88+R8jNNyaEX7iQFs7UfCib6rcY/9+ICR4jhjFCQ==
+  dependencies:
+    semver "^5.3.0"
+
 babel-plugin-ember-modules-api-polyfill@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.6.0.tgz#9524a65ef0c31ee82536a19c243fbaec1b977cbb"


### PR DESCRIPTION
Dropping the beta tag and updating to the latest release version

This release dropped support for node 4, but that was dropped here already.