### PR TITLE
chore: adds homepage field to pkg.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "transpile",
     "transpiler"
   ],
+  "homepage": "https://github.com/babel/ember-cli-babel",
   "bugs": {
     "url": "https://github.com/babel/ember-cli-babel/issues"
   },


### PR DESCRIPTION
Minor but enhances the experience within tools like vscode for quick linking to the project from within pkg.json