### PR TITLE
README: Make wording in links more active

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ code through the transpiler shouldn't change the code at all (likely just a
 format change if it does).
 
 If you need to customize the way that `babel-preset-env` configures the plugins
-that transform your code, you can do it by passing in any of the options found
-[here](https://github.com/babel/babel-preset-env/tree/v1.6.1#options). *Note:
-`.babelrc` files are ignored by default.*
+that transform your code, you can do it by passing in any of the
+[babel/babel-preset-env options](https://github.com/babel/babel-preset-env/tree/v1.6.1#options).
+*Note: `.babelrc` files are ignored by default.*
 
 Example (configuring babel directly):
 
@@ -368,12 +368,11 @@ namespace.
 #### Parallel Builds
 
 By default, [broccoli-babel-transpiler] will attempt to spin up several
-sub-processes (~1 per available core), to achieve parallelization. (Once node
-has built-in worker support, we plan to utilize). This yields significant babel
+sub-processes (~1 per available core), to achieve parallelization. (Once Node.js
+has built-in worker support, we plan to utilize it.) This yields significant Babel
 build time improvements.
 
-Unfortunately, some babel-plugins may break this functionality [More
-Details](https://github.com/babel/broccoli-babel-transpiler#parallel-transpilation).
+Unfortunately, some Babel plugins may break this functionality.
 When this occurs, we gracefully fallback to the old serial strategy.
 
 To have the build fail when failing to do parallel builds, opt-in is via:
@@ -385,7 +384,9 @@ let app = new EmberAddon(defaults, {
   }
 });
 ```
-*note: future versions will enable this flag by default*
+*Note: Future versions will enable this flag by default.*
 
-[More Details re: broccoli parallel builds](https://github.com/babel/broccoli-babel-transpiler#parallel-transpilation)
+Read more about [broccoli parallel transpilation].
 
+[broccoli-babel-transpiler]: https://github.com/babel/broccoli-babel-transpiler
+[broccoli parallel transpilation]: https://github.com/babel/broccoli-babel-transpiler#parallel-transpilation


### PR DESCRIPTION
This PR tries to improve the scannability of the README.

  - make link texts longer and more explicit
  - spell out node as Node.js in a sentence
  - capitalize some project names
  - use Markdown reference links (easier to read the _source_)
