### PR TITLE
[BUGFIX] Dedupe internal decorators plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -345,6 +345,14 @@ module.exports = {
       plugins.push([require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }]);
     }
 
+    if (hasPlugin(target, 'babel-plugin-filter-imports')) {
+      let checker = new VersionChecker(this.parent).for('babel-plugin-filter-imports', 'npm');
+
+      if (checker.lt('3.0.0')) {
+        plugins.push([require.resolve('./lib/dedupe-internal-decorators-plugin')]);
+      }
+    }
+
     return plugins;
   },
 

--- a/lib/dedupe-internal-decorators-plugin.js
+++ b/lib/dedupe-internal-decorators-plugin.js
@@ -1,0 +1,13 @@
+module.exports = () => ({
+  manipulateOptions: (opts, parserOptions) => {
+    let decoratorsPluginIndex = parserOptions.plugins.findIndex(
+      p =>
+        Array.isArray(p) &&
+        p[0] === 'decorators' &&
+        p[1].decoratorsBeforeExport &&
+        p[1].legacy
+    );
+
+    parserOptions.plugins.splice(decoratorsPluginIndex, 1);
+  },
+});


### PR DESCRIPTION
babel-plugin-filter-imports currently adds the internal
`decorators` plugin so it can parse and remove decorators,
but this conflicts with the _actual_ decorators plugin. This
PR dedupes the plugins for now (and for previous users of
babel-plugin-filter-imports), we'll also release a new major
version of that plugin that doesn't add the internal plugin.

Related: https://github.com/ember-cli/babel-plugin-filter-imports/pull/135