### PR TITLE
[BUGFIX] Ensure class properties/decorator plugins are added in correct order

### DIFF
--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -684,41 +684,33 @@ describe('ember-cli-babel', function() {
     });
   });
 
-  describe('_getDecoratorPlugins', function() {
+  describe('_addDecoratorPlugins', function() {
     it('should include babel transforms by default', function() {
-      expect(this.addon._getDecoratorPlugins({}).length).to.equal(2, 'plugins added correctly');
+      expect(this.addon._addDecoratorPlugins([]).length).to.equal(2, 'plugins added correctly');
     });
 
-    it('should not include babel transforms if it detects decorators plugin', function() {
+    it('should include only fields if it detects decorators plugin', function() {
       this.addon.project.ui = {
         writeWarnLine(message) {
-          expect(message).to.match(/has added the decorators and\/or class properties plugins to its build/);
+          expect(message).to.match(/has added the decorators plugin to its build/);
         }
       };
 
-      expect(this.addon._getDecoratorPlugins({
-        babel: {
-          plugins: [
-            ['@babel/plugin-proposal-decorators']
-          ]
-        }
-      }).length).to.equal(0, 'plugins were not added');
+      expect(this.addon._addDecoratorPlugins([
+        ['@babel/plugin-proposal-decorators']
+      ]).length).to.equal(2, 'plugins were not added');
     });
 
-    it('should not include babel transforms if it detects class fields plugin', function() {
+    it('should include only decorators if it detects class fields plugin', function() {
       this.addon.project.ui = {
         writeWarnLine(message) {
-          expect(message).to.match(/has added the decorators and\/or class properties plugins to its build/);
+          expect(message).to.match(/has added the class-properties plugin to its build/);
         }
       };
 
-      expect(this.addon._getDecoratorPlugins({
-        babel: {
-          plugins: [
-            ['@babel/plugin-proposal-class-properties']
-          ]
-        }
-      }).length).to.equal(0, 'plugins were not added');
+      expect(this.addon._addDecoratorPlugins([
+        ['@babel/plugin-proposal-class-properties']
+      ]).length).to.equal(2, 'plugins were not added');
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "broccoli-funnel": "^2.0.1",
     "broccoli-source": "^1.1.0",
     "clone": "^2.1.2",
-    "ember-cli-babel-plugin-helpers": "^1.0.2",
+    "ember-cli-babel-plugin-helpers": "^1.1.0",
     "ember-cli-version-checker": "^2.1.2",
     "ensure-posix-path": "^1.0.2",
     "semver": "^5.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2903,10 +2903,10 @@ ember-assign-polyfill@~2.4.0:
     ember-cli-babel "^6.6.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-cli-babel-plugin-helpers@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.0.2.tgz#d4bec0f32febc530e621ea8d66d3365727cb5e6c"
-  integrity sha512-tTWmHiIvadgtu0i+Zlb5Jnue69qO6dtACcddkRhhV+m9NfAr+2XNoTKRSeGL8QyRDhfWeo4rsK9dqPrU4PQ+8g==
+ember-cli-babel-plugin-helpers@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
+  integrity sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==
 
 ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.18.0"


### PR DESCRIPTION
This PR uses the updated babel-plugin-helpers library to actually modify
the user's plugins and add the decorator/class properties transforms
relative to each other, if one shouldn't exist. They are also
constrained to come _before_ the Typescript transforms, should they
exist. This allows TS to react to any of the output of the previous
transforms.