### PR TITLE
Use default targets configuration for transpilation tests.

### DIFF
--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -25,7 +25,10 @@ describe('ember-cli-babel', function() {
       root: __dirname,
       emberCLIVersion: () => '2.16.2',
       dependencies() { return {}; },
-      addons: []
+      addons: [],
+      targets: {
+        browsers: ['ie 11'],
+      },
     };
 
     this.addon = new Addon({
@@ -310,7 +313,10 @@ describe('ember-cli-babel', function() {
           root: input.path(),
           emberCLIVersion: () => '2.16.2',
           dependencies() { return dependencies; },
-          addons: []
+          addons: [],
+          targets: {
+            browsers: ['ie 11'],
+          },
         };
 
         this.addon = new Addon({
@@ -376,8 +382,10 @@ describe('ember-cli-babel', function() {
           root: input.path(),
           emberCLIVersion: () => '2.16.2',
           dependencies() { return dependencies; },
-          addons: [
-          ]
+          addons: [ ],
+          targets: {
+            browsers: ['ie 11'],
+          },
         };
         let projectsBabel = new Addon({
           project,
@@ -452,7 +460,10 @@ describe('ember-cli-babel', function() {
           root: input.path(),
           emberCLIVersion: () => '2.16.2',
           dependencies() { return dependencies; },
-          addons: []
+          addons: [],
+          targets: {
+            browsers: ['ie 11'],
+          },
         };
 
         this.addon = new Addon({
@@ -518,8 +529,10 @@ describe('ember-cli-babel', function() {
           root: input.path(),
           emberCLIVersion: () => '2.16.2',
           dependencies() { return dependencies; },
-          addons: [
-          ]
+          addons: [ ],
+          targets: {
+            browsers: ['ie 11'],
+          },
         };
         let projectsBabel = new Addon({
           project,
@@ -1101,7 +1114,7 @@ describe('ember-cli-babel', function() {
         [require.resolve('@babel/preset-env'), {
           loose: true,
           modules: false,
-          targets: undefined,
+          targets: { browsers: ['ie 11'] },
         }],
       ]);
     });


### PR DESCRIPTION
In @babel/preset-env@7.4.3 3 new plugins are added when supporting < IE 11:

* transform-member-expression-literals
* transform-property-literals
* transform-reserved-words

Unfortunately, babel-plugin-ember-modules-api-polyfill does a "bad thing" and updates the imported identifiers value to **be** a string like `Ember.Foo` which is completely invalid. The new transforms added in @babel/preset-env@7.4.3 (correctly) try to fix invalid identifiers for IE9/IE10 and end up making the output completely incorrect.

This commit adds targets to prevent these plugins from being used in our own test harness, but we should **absolutely** fix the underlying issue upstream in babel-plugin-ember-modules-api-polyfill.

Fixes #281 
Closes #282 