### PR TITLE
Refactor CI to use stages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 ---
 language: node_js
 node_js:
-  - "6"
-  - "8"
   - "10"
 
 dist: trusty
@@ -10,25 +8,42 @@ dist: trusty
 addons:
   chrome: stable
 
+branches:
+  only:
+    - master
+    # npm version tags
+    - /^v\d+\.\d+\.\d+/
+
 cache:
   yarn: true
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
+jobs:
+  fail_fast: true
+
+  include:
+    # runs linting and tests with current locked deps
+
+    - stage: "Tests"
+      name: "Tests"
+      script:
+        - yarn lint:js
+        - yarn test
+
+    - stage: "Additional Tests"
+      name: 'Node 6'
+      node_js: 6
+
+    - name: 'Node 8'
+      node_js: 8
+
+    - name: 'Floating Dependencies'
+      install: yarn install --no-lockfile --non-interactive
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  - yarn global add phantomjs-prebuilt
-  - phantomjs --version
-
-install:
-  - yarn install --no-lockfile --non-interactive
 
 script:
-  - yarn lint:js
   - yarn test
 
 before_deploy:


### PR DESCRIPTION
Ensures our linting runs only on locked dependencies, and generally makes identifying issues due to "float" much easier to track down.