### PR TITLE
Respect babel "ignore" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ interface EmberCLIBabelConfig {
     exclude?: string[];
     useBuiltIns?: boolean;
     sourceMaps?: boolean | "inline" | "both";
+    ignore?: MatchPattern[];
     plugins?: BabelPlugin[];
   };
 

--- a/index.js
+++ b/index.js
@@ -280,11 +280,17 @@ module.exports = {
       sourceMaps = config.babel.sourceMaps;
     }
 
+    let ignore;
+    if (config.babel && 'ignore' in config.babel) {
+      ignore = config.babel.ignore;
+    }
+
     let filterExtensions = this._getExtensions(config);
 
     let options = {
       annotation: providedAnnotation || `Babel: ${this._parentName()}`,
       sourceMaps,
+      ignore,
       throwUnlessParallelizable,
       filterExtensions
     };
@@ -456,6 +462,7 @@ module.exports = {
     // delete any properties added to `options.babel` that
     // are invalid for @babel/preset-env
     delete presetOptions.sourceMaps;
+    delete presetOptions.ignore;
     delete presetOptions.plugins;
     delete presetOptions.postTransformPlugins;
 

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -1006,6 +1006,17 @@ describe('ember-cli-babel', function() {
       expect(result.sourceMaps).to.equal('inline');
     });
 
+    it('uses provided ignore option if specified', function() {
+      let options = {
+        babel: {
+          ignore: ['file/pattern/a', '**/*-snapshot.js'],
+        }
+      };
+
+      let result = this.addon.buildBabelOptions(options);
+      expect(result.ignore).to.deep.equal(['file/pattern/a', '**/*-snapshot.js']);
+    });
+
     it('disables reading `.babelrc`', function() {
       let options = {};
 


### PR DESCRIPTION
In Babel 7 the `ignore` option is no longer valid for @babel/preset-env, so there is currently no way of providing this option through ember-cli-babel.

I followed #158, which added `sourceMaps` option forwarding - this PR is pretty much the same.

Food for thought: should this plugin maybe allow the user to specify options separately for babel and for the env preset, instead of forwarding these manually? Since Babel separates them, it feels a bit weird that this plugin will bundle them together, even if it abstracts the env preset usage.

Fixes #305 