### PR TITLE
Update modules API polyfill to avoid TypeScript related errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "amd-name-resolver": "^1.2.1",
     "babel-plugin-debug-macros": "^0.3.0",
     "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
-    "babel-plugin-ember-modules-api-polyfill": "^2.13.1",
+    "babel-plugin-ember-modules-api-polyfill": "^2.13.2",
     "babel-plugin-module-resolver": "^3.1.1",
     "broccoli-babel-transpiler": "^7.4.0",
     "broccoli-debug": "^0.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,10 +1574,10 @@ babel-plugin-ember-modules-api-polyfill@^2.12.0, babel-plugin-ember-modules-api-
   dependencies:
     ember-rfc176-data "^0.3.12"
 
-babel-plugin-ember-modules-api-polyfill@^2.13.1:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.1.tgz#a529ec260ee2c5af5b5696074b23334535100368"
-  integrity sha512-h9DZ4wD7LYfKK98bZ7Rf6EX7bi5bmfO/hS/jWdqFj4OrpBa4qwRUczBDU7tUlyLcOxyXvXa6+DzXk38I65Y7vA==
+babel-plugin-ember-modules-api-polyfill@^2.13.2:
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.2.tgz#635c58120fe85caa842febb321ef173ce8528ffb"
+  integrity sha512-OHXf1pV3uiUNyc/agAofkZiA3MPQLmv4OpZ6Se8cGP1NbsvGaM5j5DdJ/nOl5y9us5/iDJGHFKq2yN1heOcUoQ==
   dependencies:
     ember-rfc176-data "^0.3.13"
 


### PR DESCRIPTION
When an imported Ember module was used as both a type and a value, the value would be replaced properly with the Ember global but when the Babel plugin attempted to rewrite the type reference to the import an error was thrown.

See https://github.com/ember-cli/babel-plugin-ember-modules-api-polyfill/pull/110 for a more detailed description.

Thanks for the fix @fivetanley!