### PR TITLE
Fix type casting and type assertion with Ember modules APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "amd-name-resolver": "^1.2.1",
     "babel-plugin-debug-macros": "^0.3.0",
     "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
-    "babel-plugin-ember-modules-api-polyfill": "^2.13.2",
+    "babel-plugin-ember-modules-api-polyfill": "^2.13.3",
     "babel-plugin-module-resolver": "^3.1.1",
     "broccoli-babel-transpiler": "^7.4.0",
     "broccoli-debug": "^0.6.4",


### PR DESCRIPTION
The prior fix for TypeScript support avoids modifying any node who's parent node's type starts with `TS`. This fixed a large number of scenarios where an identifier _happened_ to be both a type and a value.

Unfortunately, there are some cases where the parent node is a `TS*` node but the node still needs to be transpiled to use the Ember global paths. For example:

```ts
import { addObserver } from '@ember/object/observers';
(addObserver as any)();
```

In this the parent node of that `addObserver` reference is a `TSAsExpression`, but we **do** need to transpile it to `Ember.addObserver`.

And:

```ts
import { addObserver } from '@ember/object/observers';
addObserver!();
```

In this the parent node of that `addObserver` reference is a `TSNonNullExpression`, but we **do** need to transpile it to `Ember.addObserver`.

After reviewing the `@babel/plugin-transform-typescript` implementation ([see here](https://github.com/babel/babel/blob/v7.10.0/packages/babel-plugin-transform-typescript/src/index.js)) it seems that all of the other `TS*` style node types are directly removed (e.g. `path.remove()`).

Fixes #341