### PR TITLE
Ensure docs use `require.resolve` for custom plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ let app = new EmberApp({
       'transform-regenerator',
     ],
     plugins: [
-      'transform-object-rest-spread'
+      require.resolve('transform-object-rest-spread')
     ]
   }
 });
@@ -138,7 +138,7 @@ rest/spread syntax, you would do something like this in an app:
 // ember-cli-build.js
 let app = new EmberApp(defaults, {
   babel: {
-    plugins: ['transform-object-rest-spread']
+    plugins: [require.resolve('transform-object-rest-spread')]
   }
 });
 ```
@@ -148,7 +148,7 @@ In an engine:
 // index.js
 module.exports = EngineAddon.extend({
   babel: {
-    plugins: ['transform-object-rest-spread']
+    plugins: [require.resolve('transform-object-rest-spread')]
   }
 });
 ```
@@ -159,7 +159,7 @@ In an addon:
 module.exports = {
   options: {
     babel: {
-      plugins: ['transform-object-rest-spread']
+      plugins: [require.resolve('transform-object-rest-spread')]
     }
   }
 };


### PR DESCRIPTION
If you don't use `require.resolve`, it is quite easy to be trolled by resolving a different version of a given plugin than you expect.