### PR TITLE
Update babel-plugin-ember-modules-api-polyfill from 2.13.4 to 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ a shared module, reducing app size overall. This option is available _only_ to
 the root application, because it is a global configuration value due to the fact
 that there can only be one version of helpers included.
 
-Note that there is currently no way to whitelist or blacklist helpers, so all
+Note that there is currently no way to allow or ignore helpers, so all
 helpers will be included, even ones which are not used. If your app is small,
 this could add to overall build size, so be sure to check.
 
@@ -233,7 +233,7 @@ let app = new EmberApp(defaults, {
 #### Modules
 
 Older versions of Ember CLI (`< 2.12`) use its own ES6 module transpiler.
-Because of that, this plugin disables Babel module compilation by blacklisting
+Because of that, this plugin disables Babel module compilation by ignoring
 that transform when running under affected ember-cli versions. If you find that
 you want to use the Babel module transform instead of the Ember CLI one, you'll
 have to explicitly set `compileModules` to `true` in your configuration. If

--- a/index.js
+++ b/index.js
@@ -501,9 +501,9 @@ module.exports = {
     if (addonOptions.disableEmberModulesAPIPolyfill) { return; }
 
     if (this._emberVersionRequiresModulesAPIPolyfill()) {
-      const blacklist = this._getEmberModulesAPIBlacklist();
+      const ignore = this._getEmberModulesAPIIgnore();
 
-      return [[require.resolve('babel-plugin-ember-modules-api-polyfill'), { blacklist }]];
+      return [[require.resolve('babel-plugin-ember-modules-api-polyfill'), { ignore }]];
     }
   },
 
@@ -607,14 +607,14 @@ module.exports = {
     return false;
   },
 
-  _getEmberModulesAPIBlacklist() {
-    const blacklist = {
+  _getEmberModulesAPIIgnore() {
+    const ignore = {
       '@ember/debug': ['assert', 'deprecate', 'warn'],
       '@ember/application/deprecations': ['deprecate'],
     };
 
-    if (this._shouldBlacklistEmberString()) {
-      blacklist['@ember/string'] = [
+    if (this._shouldIgnoreEmberString()) {
+      ignore['@ember/string'] = [
         'fmt', 'loc', 'w',
         'decamelize', 'dasherize', 'camelize',
         'classify', 'underscore', 'capitalize',
@@ -622,11 +622,11 @@ module.exports = {
       ];
     }
 
-    if (this._shouldBlacklistJQuery()) {
-      blacklist['jquery'] = ['default'];
+    if (this._shouldIgnoreJQuery()) {
+      ignore['jquery'] = ['default'];
     }
 
-    return blacklist;
+    return ignore;
   },
 
   _isProjectName(dependency) {
@@ -640,7 +640,7 @@ module.exports = {
     )
   },
 
-  _shouldBlacklistEmberString() {
+  _shouldIgnoreEmberString() {
     let packageName = '@ember/string';
     if (this._isProjectName(packageName)) { return true; }
     if (this._isTransitiveDependency(packageName)) { return false; }
@@ -650,7 +650,7 @@ module.exports = {
     return checker.exists();
   },
 
-  _shouldBlacklistJQuery() {
+  _shouldIgnoreJQuery() {
     let packageName = '@ember/jquery';
     if (this._isProjectName(packageName)) { return true; }
     if (this._isTransitiveDependency(packageName)) { return false; }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "amd-name-resolver": "^1.2.1",
     "babel-plugin-debug-macros": "^0.3.3",
     "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
-    "babel-plugin-ember-modules-api-polyfill": "^2.13.4",
+    "babel-plugin-ember-modules-api-polyfill": "^3.0.0",
     "babel-plugin-module-resolver": "^3.1.1",
     "broccoli-babel-transpiler": "^7.5.0",
     "broccoli-debug": "^0.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2204,10 +2204,17 @@ babel-plugin-ember-data-packages-polyfill@^0.1.2:
   dependencies:
     "@ember-data/rfc395-data" "^0.0.4"
 
-babel-plugin-ember-modules-api-polyfill@^2.12.0, babel-plugin-ember-modules-api-polyfill@^2.13.4, babel-plugin-ember-modules-api-polyfill@^2.6.0:
+babel-plugin-ember-modules-api-polyfill@^2.12.0, babel-plugin-ember-modules-api-polyfill@^2.6.0:
   version "2.13.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz#cf62bc9bfd808c48d810d5194f4329e9453bd603"
   integrity sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==
+  dependencies:
+    ember-rfc176-data "^0.3.13"
+
+babel-plugin-ember-modules-api-polyfill@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.0.0.tgz#570e5992fda2516a933b8a512925e36a1ce1908c"
+  integrity sha512-enuGb9M4XYX2+OwfhoergyHqyYMj9btcWgX7f7Mq2k23ULGmj7wWU76AxwbhhT0dodjL6j5mju41Kh3Hm18uZA==
   dependencies:
     ember-rfc176-data "^0.3.13"
 


### PR DESCRIPTION
Migrate the term `blacklist` to `ignore` for that dependency.

See https://github.com/babel/ember-cli-babel/issues/355