### PR TITLE
fix: avoid assuming host app has `ember-cli-babel` installed

### DIFF
--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -446,11 +446,11 @@ function _shouldIncludeHelpers(options, appInstance) {
     shouldIncludeHelpers = defaultShouldIncludeHelpers(project);
   }
 
-  let appEmberCliBabelPackage = project.addons.find(
+  let appEmberCliBabel = project.addons.find(
     (a) => a.name === "ember-cli-babel"
-  ).pkg;
+  );
   let appEmberCliBabelVersion =
-    appEmberCliBabelPackage && appEmberCliBabelPackage.version;
+    appEmberCliBabel && appEmberCliBabel.pkg && appEmberCliBabel.pkg.version;
 
   if (
     appEmberCliBabelVersion &&

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -900,6 +900,12 @@ describe('ember-cli-babel', function() {
       expect(_shouldIncludeHelpers({}, this.addon)).to.be.false;
     });
 
+    it('should work when the host app does not include ember-cli-babel', function() {
+      this.addon.project.addons = [];
+
+      expect(_shouldIncludeHelpers({}, this.addon)).to.be.false;
+    });
+
     describe('autodetection', function() {
       it('should return true if @ember-decorators/babel-transforms exists and ember-cli-babel version is high enough', function() {
         this.addon.pkg = { version: '7.3.0-beta.1' };


### PR DESCRIPTION
The original code here assumes that searching for `ember-cli-babel` in the host app's addons always has a "hit". However, this might not be the case, if the host app is trying to experiment with some other transpiler.

The change here allows the for lookup of the package version in the host app's dependencies to return `undefined` without an error related to accessing `pkg` on `undefined`.