### PR TITLE
Ember.assert is not renamed when import { assert as X } is used

### DIFF
--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -153,7 +153,8 @@ describe('ember-cli-babel', function() {
       it("should replace imports by default", co.wrap(function* () {
         input.write({
           "foo.js": `import Component from '@ember/component'; Component.extend()`,
-          "app.js": `import Application from '@ember/application'; Application.extend()`
+          "app.js": `import Application from '@ember/application'; Application.extend()`,
+          "assert.js": `import { assert as debugAssert } from '@ember/debug';\ndebugAssert('some message', false);`,
         });
 
         subject = this.addon.transpileTree(input.path());
@@ -165,7 +166,8 @@ describe('ember-cli-babel', function() {
           output.read()
         ).to.deep.equal({
           "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  Ember.Component.extend();\n});`,
-          "app.js": `define("app", [], function () {\n  "use strict";\n\n  Ember.Application.extend();\n});`
+          "app.js": `define("app", [], function () {\n  "use strict";\n\n  Ember.Application.extend();\n});`,
+          "assert.js": `define("assert", [], function () {\n  "use strict";\n\n  (true && !(false) && Ember.assert('some message', false));\n});`
         });
       }));
 


### PR DESCRIPTION
Ref: https://github.com/babel/ember-cli-babel/issues/372