### PR TITLE
Ensure `babel.config.js` is not used without `useBabelConfig` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -330,6 +330,7 @@ module.exports = {
 
     options.highlightCode = this._shouldHighlightCode();
     options.babelrc = false;
+    options.configFile = false;
 
     return options;
   },


### PR DESCRIPTION
We have been disabling loading of `.babelrc` files for quite some time, but missed the addition of `babel.config.js` to `@babel/core`'s configuration story.

Now that we are attempting to roll out a version of ember-cli-babel that primarily leverages `babel.config.js` this mistake is coming back to haunt us. Without this explicit disabling of the `options.configFile` option ember-cli-babel versions **prior to** the ones that are adding support for `babel.config.js` (and wihtout opting in) are parsing `babel.config.js` files and ultimately breaking their builds.

Note: this should not be a breaking change as we did not really support this before (and build errors would have always occurred), but without this change it is very difficult to adopt ember-cli-babel@7.24.0's new `useBabelConfig` option.
