### PR TITLE
Use useEmberModule from modules plugin to deprecate global Ember

### DIFF
--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -127,11 +127,17 @@ function _getEmberModulesAPIPolyfill(config, parent, project) {
 
   if (_emberVersionRequiresModulesAPIPolyfill()) {
     const ignore = _getEmberModulesAPIIgnore(parent, project);
+    const useEmberModule = _shouldDeprecateGlobalEmber(parent);
 
     return [
-      [require.resolve("babel-plugin-ember-modules-api-polyfill"), { ignore }],
+      [require.resolve("babel-plugin-ember-modules-api-polyfill"), { ignore, useEmberModule }],
     ];
   }
+}
+
+function _shouldDeprecateGlobalEmber(parent) {
+  let checker = new VersionChecker(parent).for('ember-source', "npm");
+  return checker.exists() && checker.gte("3.27.0-alpha.1")
 }
 
 function _getEmberModulesAPIIgnore(parent, project) {

--- a/lib/ember-plugins.js
+++ b/lib/ember-plugins.js
@@ -91,7 +91,7 @@ function _shouldDeprecateGlobalEmber(appRoot) {
   }
 
   let pkg = require(packagePath);
-  return pkg && semver.gte(pkg.version, "3.26.0-beta.1");
+  return pkg && semver.gte(pkg.version, "3.27.0-alpha.1");
 }
 
 function _emberDataVersionRequiresPackagesPolyfill(appRoot) {

--- a/lib/ember-plugins.js
+++ b/lib/ember-plugins.js
@@ -60,9 +60,13 @@ function _getEmberModulesAPIPolyfill(appRoot, config) {
 
   if (_emberVersionRequiresModulesAPIPolyfill()) {
     const ignore = _getEmberModulesAPIIgnore(appRoot, config);
+    const useEmberModule = _shouldDeprecateGlobalEmber(appRoot);
 
     return [
-      [require.resolve("babel-plugin-ember-modules-api-polyfill"), { ignore }],
+      [
+        require.resolve("babel-plugin-ember-modules-api-polyfill"),
+        { ignore, useEmberModule },
+      ],
     ];
   }
 }
@@ -78,6 +82,16 @@ function _shouldIgnoreJQuery(appRoot) {
   }
   let pkg = require(packagePath);
   return pkg && semver.gt(pkg.version, "0.6.0");
+}
+
+function _shouldDeprecateGlobalEmber(appRoot) {
+  let packagePath = resolvePackagePath("ember-source", appRoot);
+  if (packagePath === null) {
+    return false;
+  }
+
+  let pkg = require(packagePath);
+  return pkg && semver.gte(pkg.version, "3.26.0-beta.1");
 }
 
 function _emberDataVersionRequiresPackagesPolyfill(appRoot) {
@@ -128,7 +142,7 @@ function _getEmberDataPackagesPolyfill(appRoot, config) {
 function _getModuleResolutionPlugins(config) {
   if (!config.disableModuleResolution) {
     const resolvePath = require("../lib/relative-module-paths")
-    .resolveRelativeModulePath;
+      .resolveRelativeModulePath;
     return [
       [require.resolve("babel-plugin-module-resolver"), { resolvePath }],
       [


### PR DESCRIPTION
Related: 
 - emberjs/ember.js#19357
 - https://github.com/ember-cli/babel-plugin-ember-modules-api-polyfill/pull/175