### PR TITLE
Do not transform imports to use the Ember global for ember-source@3.27 and higher

### DIFF
--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -98,11 +98,12 @@ function _getDebugMacroPlugins(config) {
   ];
 }
 
-function _emberVersionRequiresModulesAPIPolyfill() {
-  // once a version of Ember ships with the
-  // emberjs/rfcs#176 modules natively this will
-  // be updated to detect that and return false
-  return true;
+function _emberVersionRequiresModulesAPIPolyfill(parent) {
+  let checker = new VersionChecker(parent).for("ember-source", "npm");
+  if (!checker.exists()) {
+    return true;
+  }
+  return checker.lt("3.27.0-alpha.1");
 }
 
 function _emberDataVersionRequiresPackagesPolyfill(project) {
@@ -125,7 +126,7 @@ function _getEmberModulesAPIPolyfill(config, parent, project) {
     return;
   }
 
-  if (_emberVersionRequiresModulesAPIPolyfill()) {
+  if (_emberVersionRequiresModulesAPIPolyfill(parent)) {
     const ignore = _getEmberModulesAPIIgnore(parent, project);
 
     return [

--- a/lib/ember-plugins.js
+++ b/lib/ember-plugins.js
@@ -46,11 +46,14 @@ function _getDebugMacroPlugins() {
     ],
   ];
 }
-function _emberVersionRequiresModulesAPIPolyfill() {
-  // once a version of Ember ships with the
-  // emberjs/rfcs#176 modules natively this will
-  // be updated to detect that and return false
-  return true;
+function _emberVersionRequiresModulesAPIPolyfill(appRoot) {
+  let packagePath = resolvePackagePath("ember-source", appRoot);
+  if (packagePath === null) {
+    return true;
+  }
+
+  let pkg = require(packagePath);
+  return pkg && semver.lt(pkg.version, "3.27.0-alpha.1");
 }
 
 function _getEmberModulesAPIPolyfill(appRoot, config) {
@@ -58,7 +61,7 @@ function _getEmberModulesAPIPolyfill(appRoot, config) {
     return;
   }
 
-  if (_emberVersionRequiresModulesAPIPolyfill()) {
+  if (_emberVersionRequiresModulesAPIPolyfill(appRoot)) {
     const ignore = _getEmberModulesAPIIgnore(appRoot, config);
 
     return [
@@ -128,7 +131,7 @@ function _getEmberDataPackagesPolyfill(appRoot, config) {
 function _getModuleResolutionPlugins(config) {
   if (!config.disableModuleResolution) {
     const resolvePath = require("../lib/relative-module-paths")
-    .resolveRelativeModulePath;
+      .resolveRelativeModulePath;
     return [
       [require.resolve("babel-plugin-module-resolver"), { resolvePath }],
       [

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -256,12 +256,12 @@ describe('ember-cli-babel', function() {
       it(
         "should replace imports with Ember Globals",
         co.wrap(function* () {
-          const PRE_GLOBAL_RESOLVER_DEPRECATION_VERSION = "3.26.0";
+          const PRE_EMBER_MODULE_IMPORTS_VERSION = "3.26.0";
           dependencies[
             "ember-source"
-          ] = PRE_GLOBAL_RESOLVER_DEPRECATION_VERSION;
+          ] = PRE_EMBER_MODULE_IMPORTS_VERSION;
           input.write(
-            buildEmberSourceFixture(PRE_GLOBAL_RESOLVER_DEPRECATION_VERSION)
+            buildEmberSourceFixture(PRE_EMBER_MODULE_IMPORTS_VERSION)
           );
           input.write({
             "foo.js": `import Component from '@ember/component'; Component.extend()`,
@@ -1712,13 +1712,13 @@ describe('babel config file', function() {
     let self = this;
     setupForVersion = co.wrap(function*(plugins) {
       let fixturifyProject = new FixturifyProject('whatever', '0.0.1');
-      
+
       fixturifyProject.addDependency('ember-cli-babel', 'babel/ember-cli-babel#master');
       fixturifyProject.addDependency('random-addon', '0.0.1', addon => {
         return prepareAddon(addon);
       });
       let pkg = JSON.parse(fixturifyProject.toJSON('package.json'));
-      fixturifyProject.files['babel.config.js'] = 
+      fixturifyProject.files['babel.config.js'] =
       `module.exports = function (api) {
         api.cache(true);
         return {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "amd-name-resolver": "^1.3.1",
     "babel-plugin-debug-macros": "^0.3.4",
     "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
-    "babel-plugin-ember-modules-api-polyfill": "^3.4.0",
+    "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
     "babel-plugin-module-resolver": "^3.2.0",
     "broccoli-babel-transpiler": "^7.8.0",
     "broccoli-debug": "^0.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1784,12 +1784,12 @@ babel-plugin-ember-modules-api-polyfill@^2.12.0, babel-plugin-ember-modules-api-
   dependencies:
     ember-rfc176-data "^0.3.13"
 
-babel-plugin-ember-modules-api-polyfill@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.4.0.tgz#3f5e0457e135f8a29b3a8b6910806bb5b524649e"
-  integrity sha512-nVu/LqbZBAup1zLij6xGvQwVLWVk4XYu2fl4vIOUR3S6ukdonMLhKAb0d4QXSzH30Pd7OczVTlPffWbiwahdJw==
+babel-plugin-ember-modules-api-polyfill@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.5.0.tgz#27b6087fac75661f779f32e60f94b14d0e9f6965"
+  integrity sha512-pJajN/DkQUnStw0Az8c6khVcMQHgzqWr61lLNtVeu0g61LRW0k9jyK7vaedrHDWGe/Qe8sxG5wpiyW9NsMqFzA==
   dependencies:
-    ember-rfc176-data "^0.3.16"
+    ember-rfc176-data "^0.3.17"
 
 babel-plugin-htmlbars-inline-precompile@^0.2.5:
   version "0.2.6"
@@ -4091,10 +4091,15 @@ ember-resolver@^5.0.1:
     ember-cli-version-checker "^3.0.0"
     resolve "^1.10.0"
 
-ember-rfc176-data@^0.3.1, ember-rfc176-data@^0.3.13, ember-rfc176-data@^0.3.16, ember-rfc176-data@^0.3.5:
+ember-rfc176-data@^0.3.1, ember-rfc176-data@^0.3.13, ember-rfc176-data@^0.3.5:
   version "0.3.16"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.16.tgz#2ace0ac9cf9016d493a74a1d931643a308679803"
   integrity sha512-IYAzffS90r2ybAcx8c2qprYfkxa70G+/UPkxMN1hw55DU5S2aLOX6v3umKDZItoRhrvZMCnzwsdfKSrKdC9Wbg==
+
+ember-rfc176-data@^0.3.17:
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.17.tgz#d4fc6c33abd6ef7b3440c107a28e04417b49860a"
+  integrity sha512-EVzTTKqxv9FZbEh6Ktw56YyWRAA0MijKvl7H8C06wVF+8f/cRRz3dXxa4nkwjzyVwx4rzKGuIGq77hxJAQhWWw==
 
 ember-router-generator@^1.2.3:
   version "1.2.3"


### PR DESCRIPTION
PR supersedes #382 

So after some discussion in [#dev-ember-js](https://discord.com/channels/480462759797063690/485447409296736276/821417976061886524) there's been a change of plan with regards deprecating Ember Global support.

Now, rather than using `babel-plugin-ember-modules-api-polyfill`'s `useEmberModule` option to transform packages to their global equivalents and use an imported `Ember`, the plan is to no longer transform Ember package imports to use the Ember Global.

#### Source file
```js
import Component from '@ember/component'; Component.extend();
```

#### Versions of `ember-source` less than 3.27.0-alpha.1
```js
define("foo", [], function () {\n "use strict";\n\n Ember.Component.extend();\n});
```

#### Versions of `ember-source` greater than or equal to 3.27.0-alpha.1
```js
define("foo", ["@ember/component"], function (_component) {\n "use strict";\n\n _component.default.extend();\n});
```

