### PR TITLE
Refactor buildBabelOptions and introduce getSupportedExtensions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ allow you to use latest Javascript in your Ember CLI project.
     + [Adding Custom Plugins](#adding-custom-plugins)
     + [Additional Trees](#additional-trees)
     + [`buildBabelOptions` usage](#buildbabeloptions-usage)
+    + [`getSupportedExtensions` usage](#getsupportedextensions-usage)
     + [`transpileTree` usage](#transpiletree-usage)
   * [Debug Tooling](#debug-tooling)
     + [Debug Macros](#debug-macros)
@@ -410,6 +411,16 @@ let options = babelAddon.buildBabelOptions(config)
 
 // now you can pass these options off to babel or broccoli-babel-transpiler
 require('babel-core').transform('something', options);
+```
+
+#### `getSupportedExtensions` usage
+
+```js
+// find your babel addon (can use `this.findAddonByName('ember-cli-babel')` in ember-cli@2.14 and newer)
+let babelAddon = this.addons.find(addon => addon.name === 'ember-cli-babel');
+
+// create the babel options to use elsewhere based on the config above
+let extensions = babelAddon.getSupportedExtensions(config)
 ```
 
 #### `transpileTree` usage

--- a/index.js
+++ b/index.js
@@ -83,51 +83,48 @@ module.exports = {
     return this._cachedDebugTree.apply(null, arguments);
   },
 
-  /**
-   * Default babel options
-   * @param {*} config
-   */
-  _getDefaultBabelOptions(config = {}) {
-     let emberCLIBabelConfig = config["ember-cli-babel"];
-     let providedAnnotation;
-     let throwUnlessParallelizable;
-     let sourceMaps = false;
-     let shouldCompileModules = _shouldCompileModules(config, this.project);
+  _buildBroccoliBabelTranspilerOptions(config = {}) {
+    let emberCLIBabelConfig = config["ember-cli-babel"];
 
-     if (emberCLIBabelConfig) {
-       providedAnnotation = emberCLIBabelConfig.annotation;
-       throwUnlessParallelizable = emberCLIBabelConfig.throwUnlessParallelizable;
-     }
+    let providedAnnotation;
+    let throwUnlessParallelizable;
+    let sourceMaps = false;
+    let shouldCompileModules = _shouldCompileModules(config, this.project);
 
-     if (config.babel && "sourceMaps" in config.babel) {
-       sourceMaps = config.babel.sourceMaps;
-     }
+    if (emberCLIBabelConfig) {
+      providedAnnotation = emberCLIBabelConfig.annotation;
+      throwUnlessParallelizable = emberCLIBabelConfig.throwUnlessParallelizable;
+    }
 
-     let options = {
-       annotation: providedAnnotation || `Babel: ${_parentName(this.parent)}`,
-       sourceMaps,
-       throwUnlessParallelizable,
-       filterExtensions: _getExtensions(config, this.parent),
-       plugins: []
-     };
+    if (config.babel && "sourceMaps" in config.babel) {
+      sourceMaps = config.babel.sourceMaps;
+    }
 
-     if (shouldCompileModules) {
-       options.moduleIds = true;
-       options.getModuleId = require("./lib/relative-module-paths").getRelativeModulePath;
-     }
+    let options = {
+      annotation: providedAnnotation || `Babel: ${_parentName(this.parent)}`,
+      sourceMaps,
+      throwUnlessParallelizable,
+      filterExtensions: _getExtensions(config, this.parent),
+      plugins: []
+    };
 
-     options.highlightCode = _shouldHighlightCode(this.parent);
-     options.babelrc = false;
-     options.configFile = false;
+    if (shouldCompileModules) {
+      options.moduleIds = true;
+      options.getModuleId = require("./lib/relative-module-paths").getRelativeModulePath;
+    }
 
-     return options;
+    options.highlightCode = _shouldHighlightCode(this.parent);
+    options.babelrc = false;
+    options.configFile = false;
+
+    return options;
   },
 
   transpileTree(inputTree, _config) {
     let config = _config || this._getAddonOptions();
     let description = `000${++count}`.slice(-3);
     let postDebugTree = this._debugTree(inputTree, `${description}:input`);
-    let options = Object.assign({}, this._getDefaultBabelOptions(config), this.buildBabelOptions(config));
+    let options = Object.assign({}, this._buildBroccoliBabelTranspilerOptions(config), this.buildBabelOptions(config));
     let output;
 
     const customAddonConfig = config['ember-cli-babel'];

--- a/index.js
+++ b/index.js
@@ -83,6 +83,10 @@ module.exports = {
     return this._cachedDebugTree.apply(null, arguments);
   },
 
+  getSupportedExtensions(config) {
+    return _getExtensions(config, this.parent);
+  },
+
   _buildBroccoliBabelTranspilerOptions(config = {}) {
     let emberCLIBabelConfig = config["ember-cli-babel"];
 
@@ -104,7 +108,7 @@ module.exports = {
       annotation: providedAnnotation || `Babel: ${_parentName(this.parent)}`,
       sourceMaps,
       throwUnlessParallelizable,
-      filterExtensions: _getExtensions(config, this.parent),
+      filterExtensions: this.getSupportedExtensions(config),
       plugins: []
     };
 

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -1143,7 +1143,7 @@ describe('ember-cli-babel', function() {
     it('disables reading `.babelrc`', function() {
       let options = {};
 
-      let result = this.addon._getDefaultBabelOptions(options);
+      let result = this.addon._buildBroccoliBabelTranspilerOptions(options);
 
       expect(result.babelrc).to.be.false;
     });
@@ -1153,7 +1153,7 @@ describe('ember-cli-babel', function() {
         name: 'derpy-herpy',
         dependencies() { return {}; },
       });
-      let result = this.addon._getDefaultBabelOptions();
+      let result = this.addon._buildBroccoliBabelTranspilerOptions();
       expect(result.annotation).to.include('derpy-herpy');
     });
 
@@ -1162,7 +1162,7 @@ describe('ember-cli-babel', function() {
         name: 'derpy-herpy',
         dependencies() { return {}; },
       });
-      let result = this.addon._getDefaultBabelOptions();
+      let result = this.addon._buildBroccoliBabelTranspilerOptions();
       expect(result.annotation).to.include('derpy-herpy');
     });
 
@@ -1173,7 +1173,7 @@ describe('ember-cli-babel', function() {
         }
       };
 
-      let result = this.addon._getDefaultBabelOptions(options);
+      let result = this.addon._buildBroccoliBabelTranspilerOptions(options);
       expect(result.annotation).to.equal('Hello World!');
     });
 
@@ -1184,14 +1184,14 @@ describe('ember-cli-babel', function() {
         }
       };
 
-      let result = this.addon._getDefaultBabelOptions(options);
+      let result = this.addon._buildBroccoliBabelTranspilerOptions(options);
       expect(result.sourceMaps).to.equal('inline');
     });
 
     it('disables reading `.babelrc`', function() {
       let options = {};
 
-      let result = this.addon._getDefaultBabelOptions(options);
+      let result = this.addon._buildBroccoliBabelTranspilerOptions(options);
 
       expect(result.babelrc).to.be.false;
     });


### PR DESCRIPTION
- Ensure `buildBabelOptions` accounts for `babel.config.js`.
- Rename `_getDefaultBabelOptions` to `buildBroccoliBabelTranspilerOptions`
- Expose `getSupportedExtensions` method.

The goal here is to fixup some options building issues, and expose a public API that ember-auto-import can use that doesn't rely on the bug @ef4 reported in https://github.com/babel/ember-cli-babel/issues/227.

* https://github.com/babel/ember-cli-babel/issues/389
* https://github.com/ef4/ember-auto-import/issues/359