### PR TITLE
Fix compatibility with ember-auto-import.

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ interface EmberCLIBabel {
   /**
     Used to generate the options that will ultimately be passed to babel itself.
   */
-  buildBabelOptions(config?: EmberCLIBabelConfig): Opaque;
+  buildBabelOptions(type: 'babel' | 'broccoli', config?: EmberCLIBabelConfig): Opaque;
 
   /**
     Supports easier transpilation of non-standard input paths (e.g. to transpile
@@ -407,7 +407,7 @@ interface EmberCLIBabel {
 let babelAddon = this.addons.find(addon => addon.name === 'ember-cli-babel');
 
 // create the babel options to use elsewhere based on the config above
-let options = babelAddon.buildBabelOptions(config)
+let options = babelAddon.buildBabelOptions('babel', config)
 
 // now you can pass these options off to babel or broccoli-babel-transpiler
 require('babel-core').transform('something', options);

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -1137,7 +1137,7 @@ describe('ember-cli-babel', function() {
     });
   });
 
-  describe('buildBabelOptions', function() {
+  describe('_buildBroccoliBabelTranspilerOptions', function() {
     this.timeout(0);
 
     it('disables reading `.babelrc`', function() {
@@ -1195,6 +1195,51 @@ describe('ember-cli-babel', function() {
 
       expect(result.babelrc).to.be.false;
     });
+  });
+
+  describe('buildBabelOptions', function() {
+    this.timeout(0);
+
+    it('returns broccoli-babel-transpiler options by default', function() {
+      let result = this.addon.buildBabelOptions();
+
+      expect(result.moduleIds).to.be.true;
+      expect(result.annotation).to.be;
+      expect(result.babelrc).to.be.false;
+      expect(result.configFile).to.be.false;
+    });
+
+    it('returns broccoli-babel-transpiler options when asked for', function() {
+      let result = this.addon.buildBabelOptions('broccoli');
+
+      expect(result.moduleIds).to.be.true;
+      expect(result.annotation).to.be;
+      expect(result.babelrc).to.be.false;
+      expect(result.configFile).to.be.false;
+    });
+
+    it('returns broccoli-babel-transpiler options with customizations when provided', function() {
+      let result = this.addon.buildBabelOptions('broccoli', {
+        'ember-cli-babel': {
+          annotation: 'hello!!!',
+        }
+      });
+
+      expect(result.annotation).to.equal('hello!!!');
+      expect(result.moduleIds).to.be.true;
+      expect(result.annotation).to.be;
+      expect(result.babelrc).to.be.false;
+      expect(result.configFile).to.be.false;
+    });
+
+    it('returns babel options when asked for', function() {
+      let result = this.addon.buildBabelOptions('babel');
+
+      expect('moduleIds' in result).to.be.false;
+      expect('annotation' in result).to.be.false;
+      expect('babelrc' in result).to.be.false;
+      expect('configFile' in result).to.be.false;
+    });
 
     it('does not include all provided options', function() {
       let babelOptions = { blah: true };
@@ -1202,7 +1247,7 @@ describe('ember-cli-babel', function() {
         babel: babelOptions
       };
 
-      let result = this.addon.buildBabelOptions(options);
+      let result = this.addon.buildBabelOptions('babel', options);
       expect(result.blah).to.be.undefined;
     });
 


### PR DESCRIPTION
ember-cli-babel@7.24 accidentally broke compatibility with ember-auto-import when it fixed `buildBabelOptions` to only return custom babel config **not** broccoli-babel-transpiler config.

This fixes that compatiblity in the case where `babelAddon.buildBabelOptions()` is called, but still preserves the ability to get _either_ the broccoli-babel-transpiler config _or_ the `@babel/core` config.

Fixes https://github.com/ef4/ember-auto-import/issues/359
Fixes https://github.com/babel/ember-cli-babel/issues/389
Related to https://github.com/ef4/ember-auto-import/pull/362
