### PR TITLE
Include addon name directory in 'treeForAddon'

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,11 +245,15 @@ module.exports = {
       destDir: '@babel/runtime/helpers/esm'
     });
 
-    return this.transpileTree(babelHelpersTree, {
+    const transpiledHelpers = this.transpileTree(babelHelpersTree, {
       'ember-cli-babel': {
         // prevents the helpers from being double transpiled, and including themselves
         disablePresetEnv: true
       }
+    });
+
+    return new Funnel(transpiledHelpers, {
+      destDir: this.moduleName(),
     });
   },
 


### PR DESCRIPTION
Info
-----
* The default `treeForAddon` method provided by `ember-cli` ensures that all compiled assets are put into a directory named after the addon itself (see https://github.com/ember-cli/ember-cli/blob/9911f5493c00986ac2d0be104a80152426240a30/lib/models/addon.js#L1196)
* With its custom `treeForAddon` method, however, `ember-cli-babel` currently doesn't do that for the babel helpers.
* This can cause issues when the build system (e.g. [Embroider](https://github.com/embroider-build/embroider)) expects that behavior from an addon.

Changes
-----
* Added a `Funnel` that includes the addon module name directory when building the Babel helpers (using the same `moduleName` method that the base addon class uses.