### PR TITLE
fix modules-api version checker

### DIFF
--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -46,7 +46,7 @@ function _shouldHighlightCode(parent) {
   return checker.gte("2.1.0");
 }
 
-function _getDebugMacroPlugins(config, parent) {
+function _getDebugMacroPlugins(config, project) {
   let addonOptions = config["ember-cli-babel"] || {};
 
   if (addonOptions.disableDebugTooling) {
@@ -84,7 +84,7 @@ function _getDebugMacroPlugins(config, parent) {
     },
   };
 
-  if (_emberVersionRequiresModulesAPIPolyfill(parent)) {
+  if (_emberVersionRequiresModulesAPIPolyfill(project)) {
     emberDebugOptions.externalizeHelpers = {
       global: "Ember",
     };
@@ -114,8 +114,8 @@ function _getDebugMacroPlugins(config, parent) {
   ];
 }
 
-function _emberVersionRequiresModulesAPIPolyfill(parent) {
-  let checker = new VersionChecker(parent).for("ember-source", "npm");
+function _emberVersionRequiresModulesAPIPolyfill(project) {
+  let checker = new VersionChecker(project).for("ember-source", "npm");
   if (!checker.exists()) {
     return true;
   }
@@ -144,7 +144,7 @@ function _getEmberModulesAPIPolyfill(config, parent, project) {
     return;
   }
 
-  if (_emberVersionRequiresModulesAPIPolyfill(parent)) {
+  if (_emberVersionRequiresModulesAPIPolyfill(project)) {
     const ignore = _getEmberModulesAPIIgnore(parent, project);
 
     return [

--- a/lib/get-babel-options.js
+++ b/lib/get-babel-options.js
@@ -51,7 +51,7 @@ module.exports = function getBabelOptions(config, appInstance) {
     .concat(
       shouldIncludeHelpers && _getHelpersPlugin(project),
       userPlugins,
-      _getDebugMacroPlugins(config, parent),
+      _getDebugMacroPlugins(config, project),
       _getEmberModulesAPIPolyfill(config, parent, project),
       _getEmberDataPackagesPolyfill(config, parent),
       _shouldCompileModules(config, project) && _getModulesPlugin(),


### PR DESCRIPTION
The check for ember-source `lt("3.27.0-alpha.1")` was incorrectly looking at the parent package instead of the project root.

This caused the modules-api-polyfill to be active in addons when it shouldn't be, resulting in confusing deprecation spew as the plugin emits deprecated usage of the Ember global.