### PR TITLE
Update `_shouldHandleTypeScript` to read from `pkg.dependencies` instead of relying on `addons`

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ module.exports = {
   },
 
   getSupportedExtensions(config = {}) {
-    return _getExtensions(config, this.parent);
+    return _getExtensions(config, this.parent, this.project);
   },
 
   _buildBroccoliBabelTranspilerOptions(config = {}) {
@@ -160,7 +160,7 @@ module.exports = {
       let BabelTranspiler = require('broccoli-babel-transpiler');
       let transpilationInput = postDebugTree;
 
-      if (_shouldHandleTypeScript(config, this.parent)) {
+      if (_shouldHandleTypeScript(config, this.parent, this.project)) {
         let Funnel = require('broccoli-funnel');
         let inputWithoutDeclarations = new Funnel(transpilationInput, { exclude: ['**/*.d.ts'] });
         transpilationInput = this._debugTree(inputWithoutDeclarations, `${description}:filtered-input`);
@@ -175,7 +175,7 @@ module.exports = {
   setupPreprocessorRegistry(type, registry) {
     registry.add('js', {
       name: 'ember-cli-babel',
-      ext: _getExtensions(this._getAddonOptions(), this.parent),
+      ext: _getExtensions(this._getAddonOptions(), this.parent, this.project),
       toTree: (tree) => this.transpileTree(tree)
     });
   },

--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -407,6 +407,26 @@ function _shouldIncludeDecoratorPlugins(config) {
   return customOptions.disableDecoratorTransforms !== true;
 }
 
+/**
+ * Returns whether we should handle TypeScript (based on the existence of
+ * `ember-cli-typescript` as a depenency). It's worth noting that we parse
+ * the `package.json` deps/devDeps directly (rather than using `addons` on
+ * the parent) because it's possible for `ember-cli-typescript` not to exist
+ * on the addons array, even if it is a dependency.
+ *
+ * Some more context:
+ *
+ * `ember-cli-typescript` returns a stable cache key so its possible for it to
+ * be deduped as part of `ember-engines`. The reason this is important is because
+ * `ember-engines` dedupe is _stateful_ so it's possible for `ember-cli-typescript`
+ * to not be part of the addons array when `ember-cli-babel` is running.
+ * 
+ * For more info on `ember-engines` dedupe logic:
+ * https://github.com/ember-engines/ember-engines/blob/master/packages/ember-engines/lib/utils/deeply-non-duplicated-addon.js#L35
+ *
+ * @name _shouldHandleTypeScript
+ * @returns {boolean}
+ */
 function _shouldHandleTypeScript(config, parent, project) {
   let emberCLIBabelConfig = config["ember-cli-babel"] || {};
 
@@ -422,6 +442,8 @@ function _shouldHandleTypeScript(config, parent, project) {
 
   let dependencies;
 
+  // consider `dependencies` and `devDependencies` if the parent is the project
+  // (`ember-cli` uses both in this case), otherwise only care about `dependencies`
   if (parent === project) {
     dependencies = Object.assign({}, pkg.dependencies, pkg.devDependencies);
   } else {

--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -1,4 +1,5 @@
 const VersionChecker = require("ember-cli-version-checker");
+const resolvePackagePath = require("resolve-package-path");
 const clone = require("clone");
 const semver = require("semver");
 
@@ -264,10 +265,10 @@ function _getHelperVersion(project) {
   return APP_BABEL_RUNTIME_VERSION.get(project);
 }
 
-function _buildClassFeaturePluginConstraints(constraints, config, parent) {
+function _buildClassFeaturePluginConstraints(constraints, config, parent, project) {
   // With versions of ember-cli-typescript < 4.0, class feature plugins like
   // @babel/plugin-proposal-class-properties were run before the TS transform.
-  if (!_shouldHandleTypeScript(config, parent)) {
+  if (!_shouldHandleTypeScript(config, parent, project)) {
     constraints.before = constraints.before || [];
     constraints.before.push("@babel/plugin-transform-typescript");
   }
@@ -295,7 +296,8 @@ function _addDecoratorPlugins(plugins, options, config, parent, project) {
           before: ["@babel/plugin-proposal-class-properties"],
         },
         config,
-        parent
+        parent,
+        project
       )
     );
   }
@@ -320,7 +322,8 @@ function _addDecoratorPlugins(plugins, options, config, parent, project) {
           after: ["@babel/plugin-proposal-decorators"],
         },
         config,
-        parent
+        parent,
+        project
       )
     );
   }
@@ -389,8 +392,8 @@ function _parentName(parent) {
   return parentName;
 }
 
-function _getExtensions(config, parent) {
-  let shouldHandleTypeScript = _shouldHandleTypeScript(config, parent);
+function _getExtensions(config, parent, project) {
+  let shouldHandleTypeScript = _shouldHandleTypeScript(config, parent, project);
   let emberCLIBabelConfig = config["ember-cli-babel"] || {};
   return (
     emberCLIBabelConfig.extensions ||
@@ -404,18 +407,41 @@ function _shouldIncludeDecoratorPlugins(config) {
   return customOptions.disableDecoratorTransforms !== true;
 }
 
-function _shouldHandleTypeScript(config, parent) {
+function _shouldHandleTypeScript(config, parent, project) {
   let emberCLIBabelConfig = config["ember-cli-babel"] || {};
+
   if (typeof emberCLIBabelConfig.enableTypeScriptTransform === "boolean") {
     return emberCLIBabelConfig.enableTypeScriptTransform;
   }
-  let typeScriptAddon =
-    parent.addons &&
-    parent.addons.find((a) => a.name === "ember-cli-typescript");
-  return (
-    typeof typeScriptAddon !== "undefined" &&
-    semver.gte(typeScriptAddon.pkg.version, "4.0.0-alpha.1")
-  );
+
+  let pkg = parent.pkg;
+
+  if (!pkg) {
+    return false;
+  }
+
+  let dependencies;
+
+  if (parent === project) {
+    dependencies = Object.assign({}, pkg.dependencies, pkg.devDependencies);
+  } else {
+    dependencies = pkg.dependencies || {};
+  }
+
+  let tsDependency = dependencies["ember-cli-typescript"];
+
+  if (tsDependency !== undefined) {
+    let tsPkgPath = resolvePackagePath("ember-cli-typescript", parent.root);
+
+    if (tsPkgPath === null) {
+      return false;
+    }
+
+    let tsPkg = require(tsPkgPath);
+    return semver.gte(tsPkg.version, "4.0.0-alpha.1");
+  }
+
+  return false;
 }
 
 function _getAddonProvidedConfig(addonOptions) {

--- a/lib/get-babel-options.js
+++ b/lib/get-babel-options.js
@@ -18,7 +18,7 @@ module.exports = function getBabelOptions(config, appInstance) {
   let { parent, project } = appInstance;
   let addonProvidedConfig = _getAddonProvidedConfig(config);
   let shouldIncludeHelpers = _shouldIncludeHelpers(config, appInstance);
-  let shouldHandleTypeScript = _shouldHandleTypeScript(config, parent);
+  let shouldHandleTypeScript = _shouldHandleTypeScript(config, parent, project);
   let shouldIncludeDecoratorPlugins = _shouldIncludeDecoratorPlugins(config);
 
  let emberCLIBabelConfig = config["ember-cli-babel"];


### PR DESCRIPTION
This fixes a bug between `ember-cli-typescript`, `ember-engines` dedupe, and `ember-cli-babel`. `ember-cli-babel` uses the existence of `ember-cli-typescript` as a dependency to determine whether to process `*.ts` files; however, `ember-engines` dedupe is _stateful_ so it's possible for `ember-cli-typescript` to not be a dependency (part of `addons`) when `ember-cli-babel` is running.

For more info on `ember-engines` dedupe logic: https://github.com/ember-engines/ember-engines/blob/master/packages/ember-engines/lib/utils/deeply-non-duplicated-addon.js#L35