### PR TITLE
Fix compatibility with Ember 3.27+ when using compileModules: false.

### DIFF
--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -85,7 +85,9 @@ function _getDebugMacroPlugins(config, project) {
     },
   };
 
-  if (_emberVersionRequiresModulesAPIPolyfill(project)) {
+  // we have to use the global form when not compiling modules, because it is often used
+  // in the context of an `app.import` where there is no wrapped in an AMD module
+  if (addonOptions.compileModules === false || _emberVersionRequiresModulesAPIPolyfill(project)) {
     emberDebugOptions.externalizeHelpers = {
       global: "Ember",
     };
@@ -420,7 +422,7 @@ function _shouldIncludeDecoratorPlugins(config) {
  * be deduped as part of `ember-engines`. The reason this is important is because
  * `ember-engines` dedupe is _stateful_ so it's possible for `ember-cli-typescript`
  * to not be part of the addons array when `ember-cli-babel` is running.
- * 
+ *
  * For more info on `ember-engines` dedupe logic:
  * https://github.com/ember-engines/ember-engines/blob/master/packages/ember-engines/lib/utils/deeply-non-duplicated-addon.js#L35
  *


### PR DESCRIPTION
When using libraries that leverage `compileModules: false` (commonly used to transpile `vendor` tree's without introducing a wrapping AMD module) on Ember 3.27+ (where we don't transpile away the various `@ember/*` modules any longer) we would leave the debug module imports alone during transpilation. This resulted (in most cases) in there being a bare unwrapped and untranspiled `import` statement in `vendor.js`.  This would then fail **everything**.

This changes the logic slightly to continue transpiling to globals mode when `compileModules: false` is set.

Note: this is really just a stop gap solution (and will still cause deprecations to be emitted, addons that are currently leveraging `compileModules: false` _will_ need to make some changes for Ember 4.0 (where a global `window.Ember` will not be ambiently available).
