### PR TITLE
Fix combination usages of `compileModules` along with other flags.

### DIFF
--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -50,7 +50,8 @@ function _shouldHighlightCode(parent) {
 function _getDebugMacroPlugins(config, project) {
   let addonOptions = config["ember-cli-babel"] || {};
 
-  if (addonOptions.disableDebugTooling) {
+  let disableDebugTooling = addonOptions.disableDebugTooling;
+  if (disableDebugTooling) {
     return;
   }
 
@@ -85,21 +86,33 @@ function _getDebugMacroPlugins(config, project) {
     },
   };
 
-  // we have to use the global form when not compiling modules, because it is often used
-  // in the context of an `app.import` where there is no wrapped in an AMD module
-  if (addonOptions.compileModules === false || _emberVersionRequiresModulesAPIPolyfill(project)) {
-    emberDebugOptions.externalizeHelpers = {
-      global: "Ember",
-    };
-    emberApplicationDeprecationsOptions.externalizeHelpers = {
-      global: "Ember",
-    };
+  let useModulesVersion;
+
+  if (_emberVersionRequiresModulesAPIPolyfill(project)) {
+    useModulesVersion = false;
+  } else if (addonOptions.compileModules === false) {
+    // we have to use the global form when not compiling modules, because it is often used
+    // in the context of an `app.import` where there is no wrapped in an AMD module
+    //
+    // However, you can opt out of this behavior by explicitly specifying `disableDebugTooling`
+    useModulesVersion = disableDebugTooling === false;
   } else {
+    useModulesVersion = true;
+  }
+
+  if (useModulesVersion) {
     emberDebugOptions.externalizeHelpers = {
       module: "@ember/debug",
     };
     emberApplicationDeprecationsOptions.externalizeHelpers = {
       module: "@ember/application/deprecations",
+    };
+  } else {
+    emberDebugOptions.externalizeHelpers = {
+      global: "Ember",
+    };
+    emberApplicationDeprecationsOptions.externalizeHelpers = {
+      global: "Ember",
     };
   }
 
@@ -147,7 +160,23 @@ function _getEmberModulesAPIPolyfill(config, parent, project) {
     return;
   }
 
+  let useModulesVersion;
+
   if (_emberVersionRequiresModulesAPIPolyfill(project)) {
+    useModulesVersion = false;
+  } else if (addonOptions.compileModules === false) {
+    // we have to use the global form when not compiling modules, because it is often used
+    // in the context of an `app.import` where there is no wrapped in an AMD module
+    //
+    // However, you can opt out of this behavior by explicitly specifying `disableEmberModulesAPIPolyfill`
+    useModulesVersion = addonOptions.disableEmberModulesAPIPolyfill === false;
+  } else {
+    useModulesVersion = true;
+  }
+
+  // we have to use the global form when not compiling modules, because it is often used
+  // in the context of an `app.import` where there is no wrapped in an AMD module
+  if (!useModulesVersion) {
     const ignore = _getEmberModulesAPIIgnore(parent, project);
 
     return [


### PR DESCRIPTION
The fix that landed in #402 was not quite correct. Specifically, it did not address the scenario where you explicitly set `compileModules: false` but also set other flags that relate to modules behaviors (e.g.  `disableDebugTooling` or `disableEmberModulesAPIPolyfill`).

This adds a number of additional tests (which emulate "real world" usage from Embroider) and ensure they pass.

Also related: https://github.com/ember-polyfills/ember-cached-decorator-polyfill/issues/70