### PR TITLE
Properly handle class properties proposal

### DIFF
--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -30,8 +30,8 @@ function _getPresetEnv(config, project) {
 }
 
 function _getModulesPlugin() {
-  const resolvePath = require("./relative-module-paths")
-    .resolveRelativeModulePath;
+  const resolvePath =
+    require("./relative-module-paths").resolveRelativeModulePath;
 
   return [
     [require.resolve("babel-plugin-module-resolver"), { resolvePath }],
@@ -296,7 +296,12 @@ function _getHelperVersion(project) {
   return APP_BABEL_RUNTIME_VERSION.get(project);
 }
 
-function _buildClassFeaturePluginConstraints(constraints, config, parent, project) {
+function _buildClassFeaturePluginConstraints(
+  constraints,
+  config,
+  parent,
+  project
+) {
   // With versions of ember-cli-typescript < 4.0, class feature plugins like
   // @babel/plugin-proposal-class-properties were run before the TS transform.
   if (!_shouldHandleTypeScript(config, parent, project)) {
@@ -307,7 +312,14 @@ function _buildClassFeaturePluginConstraints(constraints, config, parent, projec
   return constraints;
 }
 
-function _addDecoratorPlugins(plugins, options, config, parent, project) {
+function _addDecoratorPlugins({
+  plugins,
+  options,
+  config,
+  parent,
+  project,
+  isClassPropertiesRequired,
+}) {
   const { hasPlugin, addPlugin } = require("ember-cli-babel-plugin-helpers");
 
   if (hasPlugin(plugins, "@babel/plugin-proposal-decorators")) {
@@ -341,7 +353,7 @@ function _addDecoratorPlugins(plugins, options, config, parent, project) {
         )} has added the class-properties plugin to its build, but ember-cli-babel provides these by default now! You can remove the transforms, or the addon that provided them, such as @ember-decorators/babel-transforms.`
       );
     }
-  } else {
+  } else if (isClassPropertiesRequired) {
     addPlugin(
       plugins,
       [

--- a/lib/get-babel-options.js
+++ b/lib/get-babel-options.js
@@ -14,14 +14,14 @@ const {
   _getPresetEnv,
 } = require("./babel-options-util");
 
-module.exports = function getBabelOptions(config, appInstance) {
-  let { parent, project } = appInstance;
+module.exports = function getBabelOptions(config, cliBabelInstance) {
+  let { parent, project } = cliBabelInstance;
   let addonProvidedConfig = _getAddonProvidedConfig(config);
-  let shouldIncludeHelpers = _shouldIncludeHelpers(config, appInstance);
+  let shouldIncludeHelpers = _shouldIncludeHelpers(config, cliBabelInstance);
   let shouldHandleTypeScript = _shouldHandleTypeScript(config, parent, project);
   let shouldIncludeDecoratorPlugins = _shouldIncludeDecoratorPlugins(config);
 
- let emberCLIBabelConfig = config["ember-cli-babel"];
+  let emberCLIBabelConfig = config["ember-cli-babel"];
   let shouldRunPresetEnv = true;
 
   if (emberCLIBabelConfig) {
@@ -38,13 +38,16 @@ module.exports = function getBabelOptions(config, appInstance) {
   }
 
   if (shouldIncludeDecoratorPlugins) {
-    userPlugins = _addDecoratorPlugins(
-      userPlugins.slice(),
-      addonProvidedConfig.options,
+    userPlugins = _addDecoratorPlugins({
+      plugins: userPlugins.slice(),
+      options: addonProvidedConfig.options,
       config,
       parent,
-      project
-    );
+      project,
+      isClassPropertiesRequired: cliBabelInstance.isPluginRequired(
+        "proposal-class-properties"
+      ),
+    });
   }
 
   options.plugins = []
@@ -56,7 +59,8 @@ module.exports = function getBabelOptions(config, appInstance) {
       _getEmberDataPackagesPolyfill(config, parent),
       _shouldCompileModules(config, project) && _getModulesPlugin(),
       userPostTransformPlugins
-    ).filter(Boolean);
+    )
+    .filter(Boolean);
 
   options.presets = [
     shouldRunPresetEnv && _getPresetEnv(addonProvidedConfig, project),

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -1,49 +1,48 @@
 /* eslint-env mocha, node */
-'use strict';
+"use strict";
 
-const co = require('co');
-const expect = require('chai').expect;
-const MockUI = require('console-ui/mock');
-const CoreObject = require('core-object');
-const AddonMixin = require('../index');
-const CommonTags = require('common-tags');
+const co = require("co");
+const expect = require("chai").expect;
+const MockUI = require("console-ui/mock");
+const CoreObject = require("core-object");
+const AddonMixin = require("../index");
+const CommonTags = require("common-tags");
 const stripIndent = CommonTags.stripIndent;
-const { ensureSymlinkSync } = require('fs-extra');
-const FixturifyProject = require('fixturify-project');
-const EmberProject = require('ember-cli/lib/models/project');
-const MockCLI = require('ember-cli/tests/helpers/mock-cli');
-const BroccoliTestHelper = require('broccoli-test-helper');
+const { ensureSymlinkSync } = require("fs-extra");
+const FixturifyProject = require("fixturify-project");
+const EmberProject = require("ember-cli/lib/models/project");
+const MockCLI = require("ember-cli/tests/helpers/mock-cli");
+const BroccoliTestHelper = require("broccoli-test-helper");
 const createBuilder = BroccoliTestHelper.createBuilder;
 const createTempDir = BroccoliTestHelper.createTempDir;
-const terminateWorkerPool = require('./utils/terminate-workers');
-const path = require('path');
-const fs = require('fs');
-const rimraf = require('rimraf');
-const clone = require('clone');
+const terminateWorkerPool = require("./utils/terminate-workers");
+const path = require("path");
+const fs = require("fs");
+const rimraf = require("rimraf");
+const clone = require("clone");
 const {
   _shouldHandleTypeScript,
   _shouldIncludeHelpers,
   _shouldCompileModules,
-  _getExtensions
+  _getExtensions,
 } = require("../lib/babel-options-util");
 
 function prepareAddon(addon) {
-  addon.pkg.keywords.push('ember-addon');
-  addon.pkg['ember-addon'] = {};
-  addon.files['index.js'] = 'module.exports = { name: require("./package").name };';
+  addon.pkg.keywords.push("ember-addon");
+  addon.pkg["ember-addon"] = {};
+  addon.files["index.js"] =
+    'module.exports = { name: require("./package").name };';
 
   return addon;
 }
 
 let Addon = CoreObject.extend(AddonMixin);
 
-describe('ember-cli-babel', function() {
-
+describe("ember-cli-babel", function () {
   const ORIGINAL_EMBER_ENV = process.env.EMBER_ENV;
 
   const POST_EMBER_MODULE_IMPORTS_VERSION = "3.27.0";
   const PRE_EMBER_MODULE_IMPORTS_VERSION = "3.26.0";
-
 
   function buildEmberSourceFixture(version) {
     return {
@@ -59,126 +58,69 @@ describe('ember-cli-babel', function() {
   let input;
   let dependencies;
 
-  beforeEach(co.wrap(function* () {
-    input = yield createTempDir();
-    dependencies = {};
-    this.ui = new MockUI();
-    let project = {
-      isEmberCLIProject: () => true,
-      _addonsInitialized: true,
-      root: input.path(),
-      emberCLIVersion: () => '2.16.2',
-      dependencies() { return dependencies; },
-      addons: [],
-      targets: {
-        browsers: ['ie 11'],
-      },
-    };
+  beforeEach(
+    co.wrap(function* () {
+      input = yield createTempDir();
+      dependencies = {};
+      this.ui = new MockUI();
+      let project = {
+        isEmberCLIProject: () => true,
+        _addonsInitialized: true,
+        root: input.path(),
+        emberCLIVersion: () => "2.16.2",
+        dependencies() {
+          return dependencies;
+        },
+        addons: [],
+        targets: {
+          browsers: ["ie 11"],
+        },
+      };
 
-    this.addon = new Addon({
-      project,
-      parent: project,
-      ui: this.ui,
-    });
+      this.addon = new Addon({
+        project,
+        parent: project,
+        ui: this.ui,
+      });
 
-    project.addons.push(this.addon);
-  }));
+      project.addons.push(this.addon);
+    })
+  );
 
-  afterEach(co.wrap(function*() {
-    if (ORIGINAL_EMBER_ENV === undefined) {
-      delete process.env.EMBER_ENV;
-    } else {
-      process.env.EMBER_ENV = ORIGINAL_EMBER_ENV;
-    }
+  afterEach(
+    co.wrap(function* () {
+      if (ORIGINAL_EMBER_ENV === undefined) {
+        delete process.env.EMBER_ENV;
+      } else {
+        process.env.EMBER_ENV = ORIGINAL_EMBER_ENV;
+      }
 
-    if (input) {
-      yield input.dispose();
-    }
-  }));
+      if (input) {
+        yield input.dispose();
+      }
+    })
+  );
 
-  describe('transpileTree', function() {
+  describe("transpileTree", function () {
     this.timeout(0);
 
     let output;
     let subject;
 
-    afterEach(co.wrap(function* () {
-      yield output.dispose();
-      // shut down workers after the tests are run so that mocha doesn't hang
-      yield terminateWorkerPool();
-    }));
+    afterEach(
+      co.wrap(function* () {
+        yield output.dispose();
+        // shut down workers after the tests are run so that mocha doesn't hang
+        yield terminateWorkerPool();
+      })
+    );
 
-    it("should build", co.wrap(function* () {
-      input.write({
-        "foo.js": `let foo = () => {};`,
-        "bar.js": `let bar = () => {};`
-      });
-
-      subject = this.addon.transpileTree(input.path());
-      output = createBuilder(subject);
-
-      yield output.build();
-
-      expect(
-        output.read()
-      ).to.deep.equal({
-        "bar.js": `define("bar", [], function () {\n  "use strict";\n\n  var bar = function bar() {};\n});`,
-        "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  var foo = function foo() {};\n});`,
-      });
-    }));
-
-    describe('ember modules API polyfill', function() {
-      it("does not transpile deprecate debug tooling import paths", co.wrap(function* () {
+    it(
+      "should build",
+      co.wrap(function* () {
         input.write({
-          "foo.js": `import { deprecate } from '@ember/debug';\ndeprecate('some message', false, {\n  id: 'special-thing',\n  until: '1.0.0'\n});`,
-          "bar.js": `import { deprecate } from '@ember/application/deprecations';\ndeprecate('some message', false, {\n  id: 'special-thing',\n  until: '1.0.0'\n});`,
-        });
-
-        subject = this.addon.transpileTree(input.path(), {
-          'ember-cli-babel': {
-            compileModules: false,
-            disableDebugTooling: true,
-          }
-        });
-
-        output = createBuilder(subject);
-
-        yield output.build();
-
-        expect(
-          output.read()
-        ).to.deep.equal({
-          "foo.js": `import { deprecate } from '@ember/debug';\ndeprecate('some message', false, {\n  id: 'special-thing',\n  until: '1.0.0'\n});`,
-          "bar.js": `import { deprecate } from '@ember/application/deprecations';\ndeprecate('some message', false, {\n  id: 'special-thing',\n  until: '1.0.0'\n});`,
-        });
-      }));
-
-      it("can opt-out via ember-cli-babel.disableEmberModulesAPIPolyfill", co.wrap(function* () {
-        input.write({
-          "foo.js": `import Component from '@ember/component';`
-        });
-
-        subject = this.addon.transpileTree(input.path(), {
-          'ember-cli-babel': {
-            disableEmberModulesAPIPolyfill: true
-          }
-        });
-
-        output = createBuilder(subject);
-
-        yield output.build();
-
-        expect(
-          output.read()
-        ).to.deep.equal({
-          "foo.js": `define("foo", ["@ember/component"], function (_component) {\n  "use strict";\n});`
-        });
-      }));
-
-      it("should replace imports by default", co.wrap(function* () {
-        input.write({
-          "foo.js": `import Component from '@ember/component'; Component.extend()`,
-          "app.js": `import Application from '@ember/application'; Application.extend()`
+          "foo.js": `let foo = () => {};`,
+          "bar.js": `let bar = () => {};`,
         });
 
         subject = this.addon.transpileTree(input.path());
@@ -186,61 +128,134 @@ describe('ember-cli-babel', function() {
 
         yield output.build();
 
-        expect(
-          output.read()
-        ).to.deep.equal({
-          "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  Ember.Component.extend();\n});`,
-          "app.js": `define("app", [], function () {\n  "use strict";\n\n  Ember.Application.extend();\n});`
+        expect(output.read()).to.deep.equal({
+          "bar.js": `define("bar", [], function () {\n  "use strict";\n\n  var bar = function bar() {};\n});`,
+          "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  var foo = function foo() {};\n});`,
         });
-      }));
+      })
+    );
 
-      it("does not remove _asyncToGenerator helper function when used together with debug-macros", co.wrap(function* () {
-        input.write({
-          "foo.js": stripIndent`
+    describe("ember modules API polyfill", function () {
+      it(
+        "does not transpile deprecate debug tooling import paths",
+        co.wrap(function* () {
+          input.write({
+            "foo.js": `import { deprecate } from '@ember/debug';\ndeprecate('some message', false, {\n  id: 'special-thing',\n  until: '1.0.0'\n});`,
+            "bar.js": `import { deprecate } from '@ember/application/deprecations';\ndeprecate('some message', false, {\n  id: 'special-thing',\n  until: '1.0.0'\n});`,
+          });
+
+          subject = this.addon.transpileTree(input.path(), {
+            "ember-cli-babel": {
+              compileModules: false,
+              disableDebugTooling: true,
+            },
+          });
+
+          output = createBuilder(subject);
+
+          yield output.build();
+
+          expect(output.read()).to.deep.equal({
+            "foo.js": `import { deprecate } from '@ember/debug';\ndeprecate('some message', false, {\n  id: 'special-thing',\n  until: '1.0.0'\n});`,
+            "bar.js": `import { deprecate } from '@ember/application/deprecations';\ndeprecate('some message', false, {\n  id: 'special-thing',\n  until: '1.0.0'\n});`,
+          });
+        })
+      );
+
+      it(
+        "can opt-out via ember-cli-babel.disableEmberModulesAPIPolyfill",
+        co.wrap(function* () {
+          input.write({
+            "foo.js": `import Component from '@ember/component';`,
+          });
+
+          subject = this.addon.transpileTree(input.path(), {
+            "ember-cli-babel": {
+              disableEmberModulesAPIPolyfill: true,
+            },
+          });
+
+          output = createBuilder(subject);
+
+          yield output.build();
+
+          expect(output.read()).to.deep.equal({
+            "foo.js": `define("foo", ["@ember/component"], function (_component) {\n  "use strict";\n});`,
+          });
+        })
+      );
+
+      it(
+        "should replace imports by default",
+        co.wrap(function* () {
+          input.write({
+            "foo.js": `import Component from '@ember/component'; Component.extend()`,
+            "app.js": `import Application from '@ember/application'; Application.extend()`,
+          });
+
+          subject = this.addon.transpileTree(input.path());
+          output = createBuilder(subject);
+
+          yield output.build();
+
+          expect(output.read()).to.deep.equal({
+            "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  Ember.Component.extend();\n});`,
+            "app.js": `define("app", [], function () {\n  "use strict";\n\n  Ember.Application.extend();\n});`,
+          });
+        })
+      );
+
+      it(
+        "does not remove _asyncToGenerator helper function when used together with debug-macros",
+        co.wrap(function* () {
+          input.write({
+            "foo.js": stripIndent`
             import { assert } from '@ember/debug';
             export default { async foo() { await this.baz; }}
-          `
-        });
+          `,
+          });
 
-        subject = this.addon.transpileTree(input.path());
-        output = createBuilder(subject);
+          subject = this.addon.transpileTree(input.path());
+          output = createBuilder(subject);
 
-        yield output.build();
+          yield output.build();
 
-        let contents = output.read()['foo.js'];
+          let contents = output.read()["foo.js"];
 
-        expect(contents).to.include('function _asyncToGenerator');
-      }));
+          expect(contents).to.include("function _asyncToGenerator");
+        })
+      );
 
-      it("allows @ember/debug to be consumed via both debug-macros and ember-modules-api-polyfill", co.wrap(function* () {
-        input.write({
-          "foo.js": stripIndent`
+      it(
+        "allows @ember/debug to be consumed via both debug-macros and ember-modules-api-polyfill",
+        co.wrap(function* () {
+          input.write({
+            "foo.js": stripIndent`
             import { assert, inspect } from '@ember/debug';
             export default { async foo() { inspect(await this.baz); }}
-          `
-        });
+          `,
+          });
 
-        subject = this.addon.transpileTree(input.path());
-        output = createBuilder(subject);
+          subject = this.addon.transpileTree(input.path());
+          output = createBuilder(subject);
 
-        yield output.build();
+          yield output.build();
 
-        let contents = output.read()['foo.js'];
+          let contents = output.read()["foo.js"];
 
-        expect(contents).to.not.include('@ember/debug');
-        expect(contents).to.include('function _asyncToGenerator');
-        expect(contents).to.include('inspect.call');
-        expect(contents).to.not.include('assert');
-      }));
+          expect(contents).to.not.include("@ember/debug");
+          expect(contents).to.include("function _asyncToGenerator");
+          expect(contents).to.include("inspect.call");
+          expect(contents).to.not.include("assert");
+        })
+      );
     });
 
     describe("Opting out of the ember modules API polyfill", function () {
       it(
         "should replace imports with Ember Globals",
         co.wrap(function* () {
-          dependencies[
-            "ember-source"
-          ] = PRE_EMBER_MODULE_IMPORTS_VERSION;
+          dependencies["ember-source"] = PRE_EMBER_MODULE_IMPORTS_VERSION;
           input.write(
             buildEmberSourceFixture(PRE_EMBER_MODULE_IMPORTS_VERSION)
           );
@@ -271,9 +286,7 @@ describe('ember-cli-babel', function() {
       it(
         "should not replace the imports with Ember Globals when using an ember-source version that supports it",
         co.wrap(function* () {
-          dependencies[
-            "ember-source"
-          ] = POST_EMBER_MODULE_IMPORTS_VERSION;
+          dependencies["ember-source"] = POST_EMBER_MODULE_IMPORTS_VERSION;
           input.write(
             buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
           );
@@ -302,70 +315,74 @@ describe('ember-cli-babel', function() {
       );
     });
 
-    describe('debug macros', function() {
-      it("can opt-out via ember-cli-babel.disableDebugTooling", co.wrap(function* () {
-        process.env.EMBER_ENV = 'development';
+    describe("debug macros", function () {
+      it(
+        "can opt-out via ember-cli-babel.disableDebugTooling",
+        co.wrap(function* () {
+          process.env.EMBER_ENV = "development";
 
-        let contents = stripIndent`
+          let contents = stripIndent`
           import { DEBUG } from '@glimmer/env';
           if (DEBUG) {
             console.log('debug mode!');
           }
         `;
 
-        input.write({
-          "foo.js": contents
-        });
-
-        subject = this.addon.transpileTree(input.path(), {
-          'ember-cli-babel': {
-            disableDebugTooling: true
-          }
-        });
-
-        output = createBuilder(subject);
-
-        yield output.build();
-
-        expect(
-          output.read()
-        ).to.deep.equal({
-          "foo.js": `define("foo", ["@glimmer/env"], function (_env) {\n  "use strict";\n\n  if (_env.DEBUG) {\n    console.log('debug mode!');\n  }\n});`
-        });
-      }));
-
-      describe('in development', function() {
-        it("should replace env flags by default ", co.wrap(function* () {
-          process.env.EMBER_ENV = 'development';
-
           input.write({
-            "foo.js": stripIndent`
-              import { DEBUG } from '@glimmer/env';
-              if (DEBUG) { console.log('debug mode!'); }
-            `
+            "foo.js": contents,
           });
 
-          subject = this.addon.transpileTree(input.path());
+          subject = this.addon.transpileTree(input.path(), {
+            "ember-cli-babel": {
+              disableDebugTooling: true,
+            },
+          });
+
           output = createBuilder(subject);
 
           yield output.build();
 
-          expect(
-            output.read()
-          ).to.deep.equal({
-            "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  if (true\n  /* DEBUG */\n  ) {\n    console.log('debug mode!');\n  }\n});`
+          expect(output.read()).to.deep.equal({
+            "foo.js": `define("foo", ["@glimmer/env"], function (_env) {\n  "use strict";\n\n  if (_env.DEBUG) {\n    console.log('debug mode!');\n  }\n});`,
           });
-        }));
+        })
+      );
 
-        it("should replace debug macros by default ", co.wrap(function* () {
-          process.env.EMBER_ENV = 'development';
+      describe("in development", function () {
+        it(
+          "should replace env flags by default ",
+          co.wrap(function* () {
+            process.env.EMBER_ENV = "development";
 
-          input.write({
-            "foo.js": stripIndent`
+            input.write({
+              "foo.js": stripIndent`
+              import { DEBUG } from '@glimmer/env';
+              if (DEBUG) { console.log('debug mode!'); }
+            `,
+            });
+
+            subject = this.addon.transpileTree(input.path());
+            output = createBuilder(subject);
+
+            yield output.build();
+
+            expect(output.read()).to.deep.equal({
+              "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  if (true\n  /* DEBUG */\n  ) {\n    console.log('debug mode!');\n  }\n});`,
+            });
+          })
+        );
+
+        it(
+          "should replace debug macros by default ",
+          co.wrap(function* () {
+            process.env.EMBER_ENV = "development";
+
+            input.write({
+              "foo.js": stripIndent`
               import { assert } from '@ember/debug';
               assert('stuff here', isNotBad());
             `,
-            "bar.js": stripIndent`
+              "bar.js": stripIndent`
               import { deprecate } from '@ember/debug';
               deprecate(
                 'foo bar baz',
@@ -376,7 +393,7 @@ describe('ember-cli-babel', function() {
                 }
               );
             `,
-            "baz.js": stripIndent`
+              "baz.js": stripIndent`
               import { deprecate } from '@ember/application/deprecations';
               deprecate(
                 'foo bar baz',
@@ -387,39 +404,38 @@ describe('ember-cli-babel', function() {
                 }
               );
             `,
-          });
+            });
 
-          subject = this.addon.transpileTree(input.path());
-          output = createBuilder(subject);
+            subject = this.addon.transpileTree(input.path());
+            output = createBuilder(subject);
 
-          yield output.build();
+            yield output.build();
 
-          expect(
-            output.read()
-          ).to.deep.equal({
-            "bar.js": `define("bar", [], function () {\n  "use strict";\n\n  (true && !(false) && Ember.deprecate('foo bar baz', false, {\n    id: 'some-id',\n    until: '1.0.0'\n  }));\n});`,
-            "baz.js": `define("baz", [], function () {\n  "use strict";\n\n  (true && !(false) && Ember.deprecate('foo bar baz', false, {\n    id: 'some-id',\n    until: '1.0.0'\n  }));\n});`,
-            "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  (true && !(isNotBad()) && Ember.assert('stuff here', isNotBad()));\n});`,
-          });
-        }));
+            expect(output.read()).to.deep.equal({
+              "bar.js": `define("bar", [], function () {\n  "use strict";\n\n  (true && !(false) && Ember.deprecate('foo bar baz', false, {\n    id: 'some-id',\n    until: '1.0.0'\n  }));\n});`,
+              "baz.js": `define("baz", [], function () {\n  "use strict";\n\n  (true && !(false) && Ember.deprecate('foo bar baz', false, {\n    id: 'some-id',\n    until: '1.0.0'\n  }));\n});`,
+              "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  (true && !(isNotBad()) && Ember.assert('stuff here', isNotBad()));\n});`,
+            });
+          })
+        );
 
-        it("should use modules for macros on Ember 3.27+", co.wrap(function* () {
-          process.env.EMBER_ENV = 'development';
+        it(
+          "should use modules for macros on Ember 3.27+",
+          co.wrap(function* () {
+            process.env.EMBER_ENV = "development";
 
-          dependencies[
-            "ember-source"
-          ] = POST_EMBER_MODULE_IMPORTS_VERSION;
-          input.write(
-            buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
-          );
+            dependencies["ember-source"] = POST_EMBER_MODULE_IMPORTS_VERSION;
+            input.write(
+              buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
+            );
 
-          input.write({
-            app: {
-              "foo.js": stripIndent`
+            input.write({
+              app: {
+                "foo.js": stripIndent`
                 import { assert } from '@ember/debug';
                 assert('stuff here', isNotBad());
               `,
-              "bar.js": stripIndent`
+                "bar.js": stripIndent`
                 import { deprecate } from '@ember/debug';
                 deprecate(
                   'foo bar baz',
@@ -430,7 +446,7 @@ describe('ember-cli-babel', function() {
                   }
                 );
               `,
-              "baz.js": stripIndent`
+                "baz.js": stripIndent`
                 import { deprecate } from '@ember/application/deprecations';
                 deprecate(
                   'foo bar baz',
@@ -441,203 +457,198 @@ describe('ember-cli-babel', function() {
                   }
                 );
               `,
-            },
-          });
+              },
+            });
 
-          subject = this.addon.transpileTree(input.path('app'));
-          output = createBuilder(subject);
+            subject = this.addon.transpileTree(input.path("app"));
+            output = createBuilder(subject);
 
-          yield output.build();
+            yield output.build();
 
-          expect(
-            output.read()
-          ).to.deep.equal({
-            "bar.js": `define("bar", ["@ember/debug"], function (_debug) {\n  "use strict";\n\n  (true && !(false) && (0, _debug.deprecate)('foo bar baz', false, {\n    id: 'some-id',\n    until: '1.0.0'\n  }));\n});`,
-            "baz.js": `define("baz", ["@ember/application/deprecations"], function (_deprecations) {\n  "use strict";\n\n  (true && !(false) && (0, _deprecations.deprecate)('foo bar baz', false, {\n    id: 'some-id',\n    until: '1.0.0'\n  }));\n});`,
-            "foo.js": `define("foo", ["@ember/debug"], function (_debug) {\n  "use strict";\n\n  (true && !(isNotBad()) && (0, _debug.assert)('stuff here', isNotBad()));\n});`,
-          });
-        }));
+            expect(output.read()).to.deep.equal({
+              "bar.js": `define("bar", ["@ember/debug"], function (_debug) {\n  "use strict";\n\n  (true && !(false) && (0, _debug.deprecate)('foo bar baz', false, {\n    id: 'some-id',\n    until: '1.0.0'\n  }));\n});`,
+              "baz.js": `define("baz", ["@ember/application/deprecations"], function (_deprecations) {\n  "use strict";\n\n  (true && !(false) && (0, _deprecations.deprecate)('foo bar baz', false, {\n    id: 'some-id',\n    until: '1.0.0'\n  }));\n});`,
+              "foo.js": `define("foo", ["@ember/debug"], function (_debug) {\n  "use strict";\n\n  (true && !(isNotBad()) && (0, _debug.assert)('stuff here', isNotBad()));\n});`,
+            });
+          })
+        );
 
-        it("when transpiling with compileModules: false it should use Ember global for previously 'fake' imports even on Ember 3.27+", co.wrap(function* () {
-          process.env.EMBER_ENV = 'development';
+        it(
+          "when transpiling with compileModules: false it should use Ember global for previously 'fake' imports even on Ember 3.27+",
+          co.wrap(function* () {
+            process.env.EMBER_ENV = "development";
 
-          dependencies[
-            "ember-source"
-          ] = POST_EMBER_MODULE_IMPORTS_VERSION;
-          input.write(
-            buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
-          );
+            dependencies["ember-source"] = POST_EMBER_MODULE_IMPORTS_VERSION;
+            input.write(
+              buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
+            );
 
-          input.write({
-            app: {
-              "foo.js": stripIndent`
+            input.write({
+              app: {
+                "foo.js": stripIndent`
                 import Component from '@ember/component';
 
                 export default class extends Component {}
               `,
-            },
-          });
+              },
+            });
 
-          this.addon.project.targets = {
-            browsers: ['last 2 chrome versions']
-          };
+            this.addon.project.targets = {
+              browsers: ["last 2 chrome versions"],
+            };
 
-          subject = this.addon.transpileTree(input.path('app'), {
-            'ember-cli-babel': {
-              compileModules: false,
-            }
-          });
-          output = createBuilder(subject);
+            subject = this.addon.transpileTree(input.path("app"), {
+              "ember-cli-babel": {
+                compileModules: false,
+              },
+            });
+            output = createBuilder(subject);
 
-          yield output.build();
+            yield output.build();
 
-          expect(
-            output.read()
-          ).to.deep.equal({
-            "foo.js": `export default class extends Ember.Component {}`,
-          });
-        }));
+            expect(output.read()).to.deep.equal({
+              "foo.js": `export default class extends Ember.Component {}`,
+            });
+          })
+        );
 
-        it("when transpiling with compileModules: false, disableEmberModulesAPIPolyfill: true it should not use Ember global for previously 'fake' imports", co.wrap(function* () {
-          process.env.EMBER_ENV = 'development';
+        it(
+          "when transpiling with compileModules: false, disableEmberModulesAPIPolyfill: true it should not use Ember global for previously 'fake' imports",
+          co.wrap(function* () {
+            process.env.EMBER_ENV = "development";
 
-          dependencies[
-            "ember-source"
-          ] = POST_EMBER_MODULE_IMPORTS_VERSION;
-          input.write(
-            buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
-          );
+            dependencies["ember-source"] = POST_EMBER_MODULE_IMPORTS_VERSION;
+            input.write(
+              buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
+            );
 
-          input.write({
-            app: {
-              "foo.js": stripIndent`
+            input.write({
+              app: {
+                "foo.js": stripIndent`
                 import Component from '@ember/component';
 
                 export default class extends Component {}
               `,
-            },
-          });
+              },
+            });
 
-          this.addon.project.targets = {
-            browsers: ['last 2 chrome versions']
-          };
+            this.addon.project.targets = {
+              browsers: ["last 2 chrome versions"],
+            };
 
-          subject = this.addon.transpileTree(input.path('app'), {
-            'ember-cli-babel': {
-              compileModules: false,
-              disableEmberModulesAPIPolyfill: true,
-            }
-          });
-          output = createBuilder(subject);
+            subject = this.addon.transpileTree(input.path("app"), {
+              "ember-cli-babel": {
+                compileModules: false,
+                disableEmberModulesAPIPolyfill: true,
+              },
+            });
+            output = createBuilder(subject);
 
-          yield output.build();
+            yield output.build();
 
-          expect(
-            output.read()
-          ).to.deep.equal({
-            "foo.js": `import Component from '@ember/component';\nexport default class extends Component {}`,
-          });
-        }));
+            expect(output.read()).to.deep.equal({
+              "foo.js": `import Component from '@ember/component';\nexport default class extends Component {}`,
+            });
+          })
+        );
 
-        it("when transpiling with compileModules: false, disableEmberModulesAPIPolyfill: false it should use global for Ember < 3.27", co.wrap(function* () {
-          process.env.EMBER_ENV = 'development';
+        it(
+          "when transpiling with compileModules: false, disableEmberModulesAPIPolyfill: false it should use global for Ember < 3.27",
+          co.wrap(function* () {
+            process.env.EMBER_ENV = "development";
 
-          dependencies[
-            "ember-source"
-          ] = PRE_EMBER_MODULE_IMPORTS_VERSION;
-          input.write(
-            buildEmberSourceFixture(PRE_EMBER_MODULE_IMPORTS_VERSION)
-          );
+            dependencies["ember-source"] = PRE_EMBER_MODULE_IMPORTS_VERSION;
+            input.write(
+              buildEmberSourceFixture(PRE_EMBER_MODULE_IMPORTS_VERSION)
+            );
 
-          input.write({
-            app: {
-              "foo.js": stripIndent`
+            input.write({
+              app: {
+                "foo.js": stripIndent`
                 import Component from '@ember/component';
 
                 export default class extends Component {}
               `,
-            },
-          });
+              },
+            });
 
-          this.addon.project.targets = {
-            browsers: ['last 2 chrome versions']
-          };
+            this.addon.project.targets = {
+              browsers: ["last 2 chrome versions"],
+            };
 
-          subject = this.addon.transpileTree(input.path('app'), {
-            'ember-cli-babel': {
-              compileModules: false,
-              disableEmberModulesAPIPolyfill: false,
-            }
-          });
-          output = createBuilder(subject);
+            subject = this.addon.transpileTree(input.path("app"), {
+              "ember-cli-babel": {
+                compileModules: false,
+                disableEmberModulesAPIPolyfill: false,
+              },
+            });
+            output = createBuilder(subject);
 
-          yield output.build();
+            yield output.build();
 
-          expect(
-            output.read()
-          ).to.deep.equal({
-            "foo.js": `export default class extends Ember.Component {}`,
-          });
-        }));
+            expect(output.read()).to.deep.equal({
+              "foo.js": `export default class extends Ember.Component {}`,
+            });
+          })
+        );
 
-        it("when transpiling with compileModules: false, disableEmberModulesAPIPolyfill: false it should use global for Ember > 3.27", co.wrap(function* () {
-          process.env.EMBER_ENV = 'development';
+        it(
+          "when transpiling with compileModules: false, disableEmberModulesAPIPolyfill: false it should use global for Ember > 3.27",
+          co.wrap(function* () {
+            process.env.EMBER_ENV = "development";
 
-          dependencies[
-            "ember-source"
-          ] = POST_EMBER_MODULE_IMPORTS_VERSION;
-          input.write(
-            buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
-          );
+            dependencies["ember-source"] = POST_EMBER_MODULE_IMPORTS_VERSION;
+            input.write(
+              buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
+            );
 
-          input.write({
-            app: {
-              "foo.js": stripIndent`
+            input.write({
+              app: {
+                "foo.js": stripIndent`
                 import Component from '@ember/component';
 
                 export default class extends Component {}
               `,
-            },
-          });
+              },
+            });
 
-          this.addon.project.targets = {
-            browsers: ['last 2 chrome versions']
-          };
+            this.addon.project.targets = {
+              browsers: ["last 2 chrome versions"],
+            };
 
-          subject = this.addon.transpileTree(input.path('app'), {
-            'ember-cli-babel': {
-              compileModules: false,
-              disableEmberModulesAPIPolyfill: false,
-            }
-          });
-          output = createBuilder(subject);
+            subject = this.addon.transpileTree(input.path("app"), {
+              "ember-cli-babel": {
+                compileModules: false,
+                disableEmberModulesAPIPolyfill: false,
+              },
+            });
+            output = createBuilder(subject);
 
-          yield output.build();
+            yield output.build();
 
-          expect(
-            output.read()
-          ).to.deep.equal({
-            "foo.js": `import Component from '@ember/component';\nexport default class extends Component {}`,
-          });
-        }));
+            expect(output.read()).to.deep.equal({
+              "foo.js": `import Component from '@ember/component';\nexport default class extends Component {}`,
+            });
+          })
+        );
 
-        it("when transpiling with compileModules: false, disableDebugTooling: false it should use modules for debug tooling", co.wrap(function* () {
-          process.env.EMBER_ENV = 'development';
+        it(
+          "when transpiling with compileModules: false, disableDebugTooling: false it should use modules for debug tooling",
+          co.wrap(function* () {
+            process.env.EMBER_ENV = "development";
 
-          dependencies[
-            "ember-source"
-          ] = POST_EMBER_MODULE_IMPORTS_VERSION;
-          input.write(
-            buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
-          );
+            dependencies["ember-source"] = POST_EMBER_MODULE_IMPORTS_VERSION;
+            input.write(
+              buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
+            );
 
-          input.write({
-            app: {
-              "foo.js": stripIndent`
+            input.write({
+              app: {
+                "foo.js": stripIndent`
                 import { assert } from '@ember/debug';
                 assert('stuff here', isNotBad());
               `,
-              "bar.js": stripIndent`
+                "bar.js": stripIndent`
                 import { deprecate } from '@ember/debug';
                 deprecate(
                   'foo bar baz',
@@ -648,7 +659,7 @@ describe('ember-cli-babel', function() {
                   }
                 );
               `,
-              "baz.js": stripIndent`
+                "baz.js": stripIndent`
                 import { deprecate } from '@ember/application/deprecations';
                 deprecate(
                   'foo bar baz',
@@ -659,45 +670,44 @@ describe('ember-cli-babel', function() {
                   }
                 );
               `,
-            },
-          });
+              },
+            });
 
-          subject = this.addon.transpileTree(input.path('app'), {
-            'ember-cli-babel': {
-              compileModules: false,
-              disableDebugTooling: false,
-            }
-          });
-          output = createBuilder(subject);
+            subject = this.addon.transpileTree(input.path("app"), {
+              "ember-cli-babel": {
+                compileModules: false,
+                disableDebugTooling: false,
+              },
+            });
+            output = createBuilder(subject);
 
-          yield output.build();
+            yield output.build();
 
-          expect(
-            output.read()
-          ).to.deep.equal({
-            "bar.js": `import { deprecate } from '@ember/debug';\n(true && !(false) && deprecate('foo bar baz', false, {\n  id: 'some-id',\n  until: '1.0.0'\n}));`,
-            "baz.js": `import { deprecate } from '@ember/application/deprecations';\n(true && !(false) && deprecate('foo bar baz', false, {\n  id: 'some-id',\n  until: '1.0.0'\n}));`,
-            "foo.js": `import { assert } from '@ember/debug';\n(true && !(isNotBad()) && assert('stuff here', isNotBad()));`,
-          });
-        }));
+            expect(output.read()).to.deep.equal({
+              "bar.js": `import { deprecate } from '@ember/debug';\n(true && !(false) && deprecate('foo bar baz', false, {\n  id: 'some-id',\n  until: '1.0.0'\n}));`,
+              "baz.js": `import { deprecate } from '@ember/application/deprecations';\n(true && !(false) && deprecate('foo bar baz', false, {\n  id: 'some-id',\n  until: '1.0.0'\n}));`,
+              "foo.js": `import { assert } from '@ember/debug';\n(true && !(isNotBad()) && assert('stuff here', isNotBad()));`,
+            });
+          })
+        );
 
-        it("when transpiling with compileModules: false, disableDebugTooling: true it should not use Ember global for debug tooling", co.wrap(function* () {
-          process.env.EMBER_ENV = 'development';
+        it(
+          "when transpiling with compileModules: false, disableDebugTooling: true it should not use Ember global for debug tooling",
+          co.wrap(function* () {
+            process.env.EMBER_ENV = "development";
 
-          dependencies[
-            "ember-source"
-          ] = POST_EMBER_MODULE_IMPORTS_VERSION;
-          input.write(
-            buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
-          );
+            dependencies["ember-source"] = POST_EMBER_MODULE_IMPORTS_VERSION;
+            input.write(
+              buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
+            );
 
-          input.write({
-            app: {
-              "foo.js": stripIndent`
+            input.write({
+              app: {
+                "foo.js": stripIndent`
                 import { assert } from '@ember/debug';
                 assert('stuff here', isNotBad());
               `,
-              "bar.js": stripIndent`
+                "bar.js": stripIndent`
                 import { deprecate } from '@ember/debug';
                 deprecate(
                   'foo bar baz',
@@ -708,7 +718,7 @@ describe('ember-cli-babel', function() {
                   }
                 );
               `,
-              "baz.js": stripIndent`
+                "baz.js": stripIndent`
                 import { deprecate } from '@ember/application/deprecations';
                 deprecate(
                   'foo bar baz',
@@ -719,45 +729,44 @@ describe('ember-cli-babel', function() {
                   }
                 );
               `,
-            },
-          });
+              },
+            });
 
-          subject = this.addon.transpileTree(input.path('app'), {
-            'ember-cli-babel': {
-              compileModules: false,
-              disableDebugTooling: true,
-            }
-          });
-          output = createBuilder(subject);
+            subject = this.addon.transpileTree(input.path("app"), {
+              "ember-cli-babel": {
+                compileModules: false,
+                disableDebugTooling: true,
+              },
+            });
+            output = createBuilder(subject);
 
-          yield output.build();
+            yield output.build();
 
-          expect(
-            output.read()
-          ).to.deep.equal({
-            "bar.js": `import { deprecate } from '@ember/debug';\ndeprecate('foo bar baz', false, {\n  id: 'some-id',\n  until: '1.0.0'\n});`,
-            "baz.js": `import { deprecate } from '@ember/application/deprecations';\ndeprecate('foo bar baz', false, {\n  id: 'some-id',\n  until: '1.0.0'\n});`,
-            "foo.js": `import { assert } from '@ember/debug';\nassert('stuff here', isNotBad());`,
-          });
-        }));
+            expect(output.read()).to.deep.equal({
+              "bar.js": `import { deprecate } from '@ember/debug';\ndeprecate('foo bar baz', false, {\n  id: 'some-id',\n  until: '1.0.0'\n});`,
+              "baz.js": `import { deprecate } from '@ember/application/deprecations';\ndeprecate('foo bar baz', false, {\n  id: 'some-id',\n  until: '1.0.0'\n});`,
+              "foo.js": `import { assert } from '@ember/debug';\nassert('stuff here', isNotBad());`,
+            });
+          })
+        );
 
-        it("when transpiling with compileModules: false, it should use Ember global even on Ember 3.27+", co.wrap(function* () {
-          process.env.EMBER_ENV = 'development';
+        it(
+          "when transpiling with compileModules: false, it should use Ember global even on Ember 3.27+",
+          co.wrap(function* () {
+            process.env.EMBER_ENV = "development";
 
-          dependencies[
-            "ember-source"
-          ] = POST_EMBER_MODULE_IMPORTS_VERSION;
-          input.write(
-            buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
-          );
+            dependencies["ember-source"] = POST_EMBER_MODULE_IMPORTS_VERSION;
+            input.write(
+              buildEmberSourceFixture(POST_EMBER_MODULE_IMPORTS_VERSION)
+            );
 
-          input.write({
-            app: {
-              "foo.js": stripIndent`
+            input.write({
+              app: {
+                "foo.js": stripIndent`
                 import { assert } from '@ember/debug';
                 assert('stuff here', isNotBad());
               `,
-              "bar.js": stripIndent`
+                "bar.js": stripIndent`
                 import { deprecate } from '@ember/debug';
                 deprecate(
                   'foo bar baz',
@@ -768,7 +777,7 @@ describe('ember-cli-babel', function() {
                   }
                 );
               `,
-              "baz.js": stripIndent`
+                "baz.js": stripIndent`
                 import { deprecate } from '@ember/application/deprecations';
                 deprecate(
                   'foo bar baz',
@@ -779,99 +788,105 @@ describe('ember-cli-babel', function() {
                   }
                 );
               `,
-            },
-          });
+              },
+            });
 
-          subject = this.addon.transpileTree(input.path('app'), {
-            'ember-cli-babel': {
-              compileModules: false,
-            }
-          });
-          output = createBuilder(subject);
+            subject = this.addon.transpileTree(input.path("app"), {
+              "ember-cli-babel": {
+                compileModules: false,
+              },
+            });
+            output = createBuilder(subject);
 
-          yield output.build();
+            yield output.build();
 
-          expect(
-            output.read()
-          ).to.deep.equal({
-            "bar.js": `(true && !(false) && Ember.deprecate('foo bar baz', false, {\n  id: 'some-id',\n  until: '1.0.0'\n}));`,
-            "baz.js": `(true && !(false) && Ember.deprecate('foo bar baz', false, {\n  id: 'some-id',\n  until: '1.0.0'\n}));`,
-            "foo.js": `(true && !(isNotBad()) && Ember.assert('stuff here', isNotBad()));`,
-          });
-        }));
+            expect(output.read()).to.deep.equal({
+              "bar.js": `(true && !(false) && Ember.deprecate('foo bar baz', false, {\n  id: 'some-id',\n  until: '1.0.0'\n}));`,
+              "baz.js": `(true && !(false) && Ember.deprecate('foo bar baz', false, {\n  id: 'some-id',\n  until: '1.0.0'\n}));`,
+              "foo.js": `(true && !(isNotBad()) && Ember.assert('stuff here', isNotBad()));`,
+            });
+          })
+        );
       });
 
-      describe('in production', function() {
-        it("should replace env flags by default ", co.wrap(function* () {
-          process.env.EMBER_ENV = 'production';
+      describe("in production", function () {
+        it(
+          "should replace env flags by default ",
+          co.wrap(function* () {
+            process.env.EMBER_ENV = "production";
 
-          input.write({
-            "foo.js": stripIndent`
+            input.write({
+              "foo.js": stripIndent`
               import { DEBUG } from '@glimmer/env';
               if (DEBUG) { console.log('debug mode!'); }
-            `
-          });
+            `,
+            });
 
-          subject = this.addon.transpileTree(input.path());
-          output = createBuilder(subject);
+            subject = this.addon.transpileTree(input.path());
+            output = createBuilder(subject);
 
-          yield output.build();
+            yield output.build();
 
-          expect(
-            output.read()
-          ).to.deep.equal({
-            "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  if (false\n  /* DEBUG */\n  ) {\n    console.log('debug mode!');\n  }\n});`
-          });
-        }));
+            expect(output.read()).to.deep.equal({
+              "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  if (false\n  /* DEBUG */\n  ) {\n    console.log('debug mode!');\n  }\n});`,
+            });
+          })
+        );
 
-        it('should replace debug macros by default ', co.wrap(function* () {
-          process.env.EMBER_ENV = 'production';
+        it(
+          "should replace debug macros by default ",
+          co.wrap(function* () {
+            process.env.EMBER_ENV = "production";
 
-          input.write({
-            "foo.js": stripIndent`
+            input.write({
+              "foo.js": stripIndent`
               import { assert } from '@ember/debug';
               assert('stuff here', isNotBad());
-            `
-          });
+            `,
+            });
 
-          subject = this.addon.transpileTree(input.path());
-          output = createBuilder(subject);
+            subject = this.addon.transpileTree(input.path());
+            output = createBuilder(subject);
 
-          yield output.build();
+            yield output.build();
 
-          expect(
-            output.read()
-          ).to.deep.equal({
-            "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  (false && !(isNotBad()) && Ember.assert('stuff here', isNotBad()));\n});`
-          });
-        }));
+            expect(output.read()).to.deep.equal({
+              "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  (false && !(isNotBad()) && Ember.assert('stuff here', isNotBad()));\n});`,
+            });
+          })
+        );
       });
     });
 
-    describe('@ember/string detection', function() {
+    describe("@ember/string detection", function () {
       function buildEmberStringFixture() {
         return {
           node_modules: {
-            '@ember': {
-              'string': {
-                'package.json': JSON.stringify({ name: '@ember/string', version: '1.0.0' }),
-                'index.js': 'module.exports = {};',
+            "@ember": {
+              string: {
+                "package.json": JSON.stringify({
+                  name: "@ember/string",
+                  version: "1.0.0",
+                }),
+                "index.js": "module.exports = {};",
               },
             },
-          }
+          },
         };
       }
 
       let dependencies;
-      beforeEach(function() {
+      beforeEach(function () {
         dependencies = {};
         let project = {
           root: input.path(),
-          emberCLIVersion: () => '2.16.2',
-          dependencies() { return dependencies; },
+          emberCLIVersion: () => "2.16.2",
+          dependencies() {
+            return dependencies;
+          },
           addons: [],
           targets: {
-            browsers: ['ie 11'],
+            browsers: ["ie 11"],
           },
         };
 
@@ -884,140 +899,156 @@ describe('ember-cli-babel', function() {
         project.addons.push(this.addon);
       });
 
-      it('does not transpile the @ember/string imports when addon is present in parent', co.wrap(function* () {
-        input.write(buildEmberStringFixture())
-        input.write({
-          app: {
-            "foo.js": stripIndent`
+      it(
+        "does not transpile the @ember/string imports when addon is present in parent",
+        co.wrap(function* () {
+          input.write(buildEmberStringFixture());
+          input.write({
+            app: {
+              "foo.js": stripIndent`
               import { camelize } from '@ember/string';
               camelize('stuff-here');
             `,
-          },
-        });
+            },
+          });
 
-        dependencies['@ember/string'] = '1.0.0';
+          dependencies["@ember/string"] = "1.0.0";
 
-        subject = this.addon.transpileTree(input.path('app'));
-        output = createBuilder(subject);
+          subject = this.addon.transpileTree(input.path("app"));
+          output = createBuilder(subject);
 
-        yield output.build();
+          yield output.build();
 
-        expect(
-          output.read()
-        ).to.deep.equal({
-          "foo.js": `define("foo", ["@ember/string"], function (_string) {\n  "use strict";\n\n  (0, _string.camelize)('stuff-here');\n});`
-        });
-      }));
+          expect(output.read()).to.deep.equal({
+            "foo.js": `define("foo", ["@ember/string"], function (_string) {\n  "use strict";\n\n  (0, _string.camelize)('stuff-here');\n});`,
+          });
+        })
+      );
 
-      it('transpiles the @ember/string imports when addon is missing', co.wrap(function* () {
-        input.write({
-          node_modules: {
-          },
-          app: {
-            "foo.js": stripIndent`
+      it(
+        "transpiles the @ember/string imports when addon is missing",
+        co.wrap(function* () {
+          input.write({
+            node_modules: {},
+            app: {
+              "foo.js": stripIndent`
               import { camelize } from '@ember/string';
               camelize('stuff-here');
             `,
-          },
-        });
+            },
+          });
 
-        subject = this.addon.transpileTree(input.path('app'));
-        output = createBuilder(subject);
+          subject = this.addon.transpileTree(input.path("app"));
+          output = createBuilder(subject);
 
-        yield output.build();
+          yield output.build();
 
-        expect(
-          output.read()
-        ).to.deep.equal({
-          "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  Ember.String.camelize('stuff-here');\n});`
-        });
-      }));
+          expect(output.read()).to.deep.equal({
+            "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  Ember.String.camelize('stuff-here');\n});`,
+          });
+        })
+      );
 
-      it('transpiles the @ember/string imports when addon is not a dependency of the parent', co.wrap(function* () {
-        let project = {
-          root: input.path(),
-          emberCLIVersion: () => '2.16.2',
-          dependencies() { return dependencies; },
-          addons: [ ],
-          targets: {
-            browsers: ['ie 11'],
-          },
-        };
-        let projectsBabel = new Addon({
-          project,
-          parent: project,
-          ui: this.ui,
-        });
-        project.addons.push(projectsBabel);
+      it(
+        "transpiles the @ember/string imports when addon is not a dependency of the parent",
+        co.wrap(function* () {
+          let project = {
+            root: input.path(),
+            emberCLIVersion: () => "2.16.2",
+            dependencies() {
+              return dependencies;
+            },
+            addons: [],
+            targets: {
+              browsers: ["ie 11"],
+            },
+          };
+          let projectsBabel = new Addon({
+            project,
+            parent: project,
+            ui: this.ui,
+          });
+          project.addons.push(projectsBabel);
 
-        let parentAddon = {
-          root: input.path('node_modules/awesome-thang'),
-          dependencies() { return dependencies; },
-          project,
-          addons: []
-        };
-        project.addons.push(parentAddon);
+          let parentAddon = {
+            root: input.path("node_modules/awesome-thang"),
+            dependencies() {
+              return dependencies;
+            },
+            project,
+            addons: [],
+          };
+          project.addons.push(parentAddon);
 
-        this.addon = new Addon({
-          project,
-          parent: project,
-          ui: this.ui,
-        });
-        parentAddon.addons.push(this.addon);
+          this.addon = new Addon({
+            project,
+            parent: project,
+            ui: this.ui,
+          });
+          parentAddon.addons.push(this.addon);
 
-        input.write({
-          node_modules: {
-            'awesome-thang': {
-              addon: {
-                "foo.js": stripIndent`
+          input.write({
+            node_modules: {
+              "awesome-thang": {
+                addon: {
+                  "foo.js": stripIndent`
                   import { camelize } from '@ember/string';
                   camelize('stuff-here');
                 `,
+                },
+                "package.json": JSON.stringify({
+                  name: "awesome-thang",
+                  private: true,
+                }),
+                "index.js": "",
               },
-              'package.json': JSON.stringify({ name: 'awesome-thang', private: true }),
-              'index.js': '',
-            }
-          }
-        });
+            },
+          });
 
-        input.write(buildEmberStringFixture());
+          input.write(buildEmberStringFixture());
 
-        subject = this.addon.transpileTree(input.path('node_modules/awesome-thang/addon'));
-        output = createBuilder(subject);
+          subject = this.addon.transpileTree(
+            input.path("node_modules/awesome-thang/addon")
+          );
+          output = createBuilder(subject);
 
-        yield output.build();
+          yield output.build();
 
-        expect(
-          output.read()
-        ).to.deep.equal({
-          "foo.js": `define(\"foo\", [], function () {\n  \"use strict\";\n\n  Ember.String.camelize('stuff-here');\n});`
-        });
-      }));
+          expect(output.read()).to.deep.equal({
+            "foo.js": `define(\"foo\", [], function () {\n  \"use strict\";\n\n  Ember.String.camelize('stuff-here');\n});`,
+          });
+        })
+      );
     });
 
-    describe('@ember/jquery detection', function() {
+    describe("@ember/jquery detection", function () {
       function buildEmberJQueryFixture() {
         return {
           node_modules: {
-            '@ember': {
-              'jquery': {
-                'package.json': JSON.stringify({ name: '@ember/jquery', version: '0.6.0' }),
-                'index.js': 'module.exports = {};',
+            "@ember": {
+              jquery: {
+                "package.json": JSON.stringify({
+                  name: "@ember/jquery",
+                  version: "0.6.0",
+                }),
+                "index.js": "module.exports = {};",
               },
             },
-          }
+          },
         };
       }
 
-      beforeEach(function() {
+      beforeEach(function () {
         dependencies = {};
         let project = {
           root: input.path(),
-          emberCLIVersion: () => '2.16.2',
-          dependencies() { return dependencies; },
+          emberCLIVersion: () => "2.16.2",
+          dependencies() {
+            return dependencies;
+          },
           addons: [],
           targets: {
-            browsers: ['ie 11'],
+            browsers: ["ie 11"],
           },
         };
 
@@ -1030,256 +1061,305 @@ describe('ember-cli-babel', function() {
         project.addons.push(this.addon);
       });
 
-      it('does not transpile the jquery imports when addon is present in parent', co.wrap(function* () {
-        input.write(buildEmberJQueryFixture());
-        input.write({
-          app: {
-            "foo.js": stripIndent`
+      it(
+        "does not transpile the jquery imports when addon is present in parent",
+        co.wrap(function* () {
+          input.write(buildEmberJQueryFixture());
+          input.write({
+            app: {
+              "foo.js": stripIndent`
               import $ from 'jquery';
               $('.foo').click();
             `,
-          },
-        });
+            },
+          });
 
-        dependencies['@ember/jquery'] = '0.6.0';
+          dependencies["@ember/jquery"] = "0.6.0";
 
-        subject = this.addon.transpileTree(input.path('app'));
-        output = createBuilder(subject);
+          subject = this.addon.transpileTree(input.path("app"));
+          output = createBuilder(subject);
 
-        yield output.build();
+          yield output.build();
 
-        expect(
-          output.read()
-        ).to.deep.equal({
-          "foo.js": `define("foo", ["jquery"], function (_jquery) {\n  "use strict";\n\n  (0, _jquery.default)('.foo').click();\n});`
-        });
-      }));
+          expect(output.read()).to.deep.equal({
+            "foo.js": `define("foo", ["jquery"], function (_jquery) {\n  "use strict";\n\n  (0, _jquery.default)('.foo').click();\n});`,
+          });
+        })
+      );
 
-      it('transpiles the jquery imports when addon is missing', co.wrap(function* () {
-        input.write({
-          node_modules: {
-          },
-          app: {
-            "foo.js": stripIndent`
+      it(
+        "transpiles the jquery imports when addon is missing",
+        co.wrap(function* () {
+          input.write({
+            node_modules: {},
+            app: {
+              "foo.js": stripIndent`
               import $ from 'jquery';
               $('.foo').click();
             `,
-          },
-        });
+            },
+          });
 
-        subject = this.addon.transpileTree(input.path('app'));
-        output = createBuilder(subject);
+          subject = this.addon.transpileTree(input.path("app"));
+          output = createBuilder(subject);
 
-        yield output.build();
+          yield output.build();
 
-        expect(
-          output.read()
-        ).to.deep.equal({
-          "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  Ember.$('.foo').click();\n});`
-        });
-      }));
+          expect(output.read()).to.deep.equal({
+            "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  Ember.$('.foo').click();\n});`,
+          });
+        })
+      );
 
-      it('transpiles the jquery imports when addon is not a dependency of the parent', co.wrap(function* () {
-        let project = {
-          root: input.path(),
-          emberCLIVersion: () => '2.16.2',
-          dependencies() { return dependencies; },
-          addons: [ ],
-          targets: {
-            browsers: ['ie 11'],
-          },
-        };
-        let projectsBabel = new Addon({
-          project,
-          parent: project,
-          ui: this.ui,
-        });
-        project.addons.push(projectsBabel);
+      it(
+        "transpiles the jquery imports when addon is not a dependency of the parent",
+        co.wrap(function* () {
+          let project = {
+            root: input.path(),
+            emberCLIVersion: () => "2.16.2",
+            dependencies() {
+              return dependencies;
+            },
+            addons: [],
+            targets: {
+              browsers: ["ie 11"],
+            },
+          };
+          let projectsBabel = new Addon({
+            project,
+            parent: project,
+            ui: this.ui,
+          });
+          project.addons.push(projectsBabel);
 
-        let parentAddon = {
-          root: input.path('node_modules/awesome-thang'),
-          dependencies() { return dependencies; },
-          project,
-          addons: []
-        };
-        project.addons.push(parentAddon);
+          let parentAddon = {
+            root: input.path("node_modules/awesome-thang"),
+            dependencies() {
+              return dependencies;
+            },
+            project,
+            addons: [],
+          };
+          project.addons.push(parentAddon);
 
-        this.addon = new Addon({
-          project,
-          parent: project,
-          ui: this.ui,
-        });
-        parentAddon.addons.push(this.addon);
+          this.addon = new Addon({
+            project,
+            parent: project,
+            ui: this.ui,
+          });
+          parentAddon.addons.push(this.addon);
 
-        input.write({
-          node_modules: {
-            'awesome-thang': {
-              addon: {
-                "foo.js": stripIndent`
+          input.write({
+            node_modules: {
+              "awesome-thang": {
+                addon: {
+                  "foo.js": stripIndent`
                   import $ from 'jquery';
                   $('.foo').click();
                 `,
+                },
+                "package.json": JSON.stringify({
+                  name: "awesome-thang",
+                  private: true,
+                }),
+                "index.js": "",
               },
-              'package.json': JSON.stringify({ name: 'awesome-thang', private: true }),
-              'index.js': '',
-            }
-          }
-        });
+            },
+          });
 
-        input.write(buildEmberJQueryFixture());
+          input.write(buildEmberJQueryFixture());
 
-        subject = this.addon.transpileTree(input.path('node_modules/awesome-thang/addon'));
-        output = createBuilder(subject);
+          subject = this.addon.transpileTree(
+            input.path("node_modules/awesome-thang/addon")
+          );
+          output = createBuilder(subject);
 
-        yield output.build();
+          yield output.build();
 
-        expect(
-          output.read()
-        ).to.deep.equal({
-          "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  Ember.$('.foo').click();\n});`
-        });
-      }));
+          expect(output.read()).to.deep.equal({
+            "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  Ember.$('.foo').click();\n});`,
+          });
+        })
+      );
     });
 
-    describe('TypeScript transpilation', function() {
+    describe("TypeScript transpilation", function () {
       let input;
       let output;
       let subject;
       let project;
       let unlink;
 
-      beforeEach(co.wrap(function*() {
-        let fixturifyProject = new FixturifyProject('whatever', '0.0.1');
-        fixturifyProject.addDependency('ember-cli-typescript', '4.0.0-alpha.1', addon => {
-          return prepareAddon(addon);
-        });
-        fixturifyProject.addDependency('ember-cli-babel', 'babel/ember-cli-babel#master');
-        let pkg = JSON.parse(fixturifyProject.toJSON('package.json'));
-        fixturifyProject.writeSync();
+      beforeEach(
+        co.wrap(function* () {
+          let fixturifyProject = new FixturifyProject("whatever", "0.0.1");
+          fixturifyProject.addDependency(
+            "ember-cli-typescript",
+            "4.0.0-alpha.1",
+            (addon) => {
+              return prepareAddon(addon);
+            }
+          );
+          fixturifyProject.addDependency(
+            "ember-cli-babel",
+            "babel/ember-cli-babel#master"
+          );
+          let pkg = JSON.parse(fixturifyProject.toJSON("package.json"));
+          fixturifyProject.writeSync();
 
-        let linkPath = path.join(fixturifyProject.root, 'whatever/node_modules/ember-cli-babel');
-        let addonPath = path.resolve(__dirname, '../');
-        rimraf.sync(linkPath);
-        fs.symlinkSync(addonPath, linkPath, 'junction');
-        unlink = () => {
-          fs.unlinkSync(linkPath);
-        };
+          let linkPath = path.join(
+            fixturifyProject.root,
+            "whatever/node_modules/ember-cli-babel"
+          );
+          let addonPath = path.resolve(__dirname, "../");
+          rimraf.sync(linkPath);
+          fs.symlinkSync(addonPath, linkPath, "junction");
+          unlink = () => {
+            fs.unlinkSync(linkPath);
+          };
 
-        let cli = new MockCLI();
-        let root = path.join(fixturifyProject.root, 'whatever');
-        project = new EmberProject(root, pkg, cli.ui, cli);
-        project.initializeAddons();
-        this.addon = project.addons.find(a => { return a.name === 'ember-cli-babel'; });
-        input = yield createTempDir();
-      }));
+          let cli = new MockCLI();
+          let root = path.join(fixturifyProject.root, "whatever");
+          project = new EmberProject(root, pkg, cli.ui, cli);
+          project.initializeAddons();
+          this.addon = project.addons.find((a) => {
+            return a.name === "ember-cli-babel";
+          });
+          input = yield createTempDir();
+        })
+      );
 
-      afterEach(co.wrap(function*() {
-        unlink();
+      afterEach(
+        co.wrap(function* () {
+          unlink();
 
-        if (input) {
-          yield input.dispose();
-        }
-
-        if (output) {
-          yield output.dispose();
-        }
-
-        // shut down workers after the tests are run so that mocha doesn't hang
-        yield terminateWorkerPool();
-      }));
-
-      it('should transpile .ts files', co.wrap(function*() {
-        input.write({ 'foo.ts': `let foo: string = "hi";` });
-
-        subject = this.addon.transpileTree(input.path());
-        output = createBuilder(subject);
-
-        yield output.build();
-
-        expect(
-          output.read()
-        ).to.deep.equal({
-          'foo.js': `define("foo", [], function () {\n  "use strict";\n\n  var foo = "hi";\n});`
-        });
-      }));
-
-      it('should exclude .d.ts files', co.wrap(function*() {
-        input.write({ 'foo.d.ts': `declare let foo: string;` });
-
-        subject = this.addon.transpileTree(input.path());
-        output = createBuilder(subject);
-
-        yield output.build();
-
-        expect(output.read()).to.deep.equal({});
-      }))
-    });
-
-    describe('_shouldDoNothing', function() {
-      it("will no-op if nothing to do", co.wrap(function* () {
-        input.write({
-          "foo.js": `invalid code`
-        });
-
-        subject = this.addon.transpileTree(input.path(), {
-          'ember-cli-babel': {
-            compileModules: false,
-            disablePresetEnv: true,
-            disableDebugTooling: true,
-            disableEmberModulesAPIPolyfill: true,
-            disableDecoratorTransforms: true,
+          if (input) {
+            yield input.dispose();
           }
-        });
 
-        output = createBuilder(subject);
+          if (output) {
+            yield output.dispose();
+          }
 
-        yield output.build();
+          // shut down workers after the tests are run so that mocha doesn't hang
+          yield terminateWorkerPool();
+        })
+      );
 
-        expect(
-          output.read()
-        ).to.deep.equal({
-          "foo.js": `invalid code`
-        });
-      }));
+      it(
+        "should transpile .ts files",
+        co.wrap(function* () {
+          input.write({ "foo.ts": `let foo: string = "hi";` });
+
+          subject = this.addon.transpileTree(input.path());
+          output = createBuilder(subject);
+
+          yield output.build();
+
+          expect(output.read()).to.deep.equal({
+            "foo.js": `define("foo", [], function () {\n  "use strict";\n\n  var foo = "hi";\n});`,
+          });
+        })
+      );
+
+      it(
+        "should exclude .d.ts files",
+        co.wrap(function* () {
+          input.write({ "foo.d.ts": `declare let foo: string;` });
+
+          subject = this.addon.transpileTree(input.path());
+          output = createBuilder(subject);
+
+          yield output.build();
+
+          expect(output.read()).to.deep.equal({});
+        })
+      );
+    });
+
+    describe("_shouldDoNothing", function () {
+      it(
+        "will no-op if nothing to do",
+        co.wrap(function* () {
+          input.write({
+            "foo.js": `invalid code`,
+          });
+
+          subject = this.addon.transpileTree(input.path(), {
+            "ember-cli-babel": {
+              compileModules: false,
+              disablePresetEnv: true,
+              disableDebugTooling: true,
+              disableEmberModulesAPIPolyfill: true,
+              disableDecoratorTransforms: true,
+            },
+          });
+
+          output = createBuilder(subject);
+
+          yield output.build();
+
+          expect(output.read()).to.deep.equal({
+            "foo.js": `invalid code`,
+          });
+        })
+      );
     });
   });
 
-  describe('getSupportedExtensions', function() {
-    it('defaults to js only', function() {
-      expect(this.addon.getSupportedExtensions()).to.have.members(['js']);
+  describe("getSupportedExtensions", function () {
+    it("defaults to js only", function () {
+      expect(this.addon.getSupportedExtensions()).to.have.members(["js"]);
     });
 
-    it('adds ts automatically', function() {
-      this.addon._shouldHandleTypeScript = function() { return true; }
+    it("adds ts automatically", function () {
+      this.addon._shouldHandleTypeScript = function () {
+        return true;
+      };
 
-      expect(this.addon.getSupportedExtensions({ 'ember-cli-babel': { enableTypeScriptTransform: true }})).to.have.members(['js', 'ts']);
+      expect(
+        this.addon.getSupportedExtensions({
+          "ember-cli-babel": { enableTypeScriptTransform: true },
+        })
+      ).to.have.members(["js", "ts"]);
     });
 
-    it('respects user-configured extensions', function() {
-      expect(this.addon.getSupportedExtensions({ 'ember-cli-babel': { extensions: ['coffee'] } })).to.have.members(['coffee']);
+    it("respects user-configured extensions", function () {
+      expect(
+        this.addon.getSupportedExtensions({
+          "ember-cli-babel": { extensions: ["coffee"] },
+        })
+      ).to.have.members(["coffee"]);
     });
 
-    it('respects user-configured extensions even when adding TS plugin', function() {
-      expect(this.addon.getSupportedExtensions({ 'ember-cli-babel': { enableTypeScriptTransform: true, extensions: ['coffee'] } })).to.have.members(['coffee']);
+    it("respects user-configured extensions even when adding TS plugin", function () {
+      expect(
+        this.addon.getSupportedExtensions({
+          "ember-cli-babel": {
+            enableTypeScriptTransform: true,
+            extensions: ["coffee"],
+          },
+        })
+      ).to.have.members(["coffee"]);
     });
   });
 
-  describe('_getAddonOptions', function() {
-    it('uses parent options if present', function() {
-      let mockOptions = this.addon.parent.options = {};
+  describe("_getAddonOptions", function () {
+    it("uses parent options if present", function () {
+      let mockOptions = (this.addon.parent.options = {});
 
       expect(this.addon._getAddonOptions()).to.be.equal(mockOptions);
     });
 
-    it('uses app options if present', function() {
+    it("uses app options if present", function () {
       let mockOptions = {};
       this.addon.app = { options: mockOptions };
 
       expect(this.addon._getAddonOptions()).to.be.equal(mockOptions);
     });
 
-    it('parent options win over app options', function() {
-      let mockParentOptions = this.addon.parent.options = {};
+    it("parent options win over app options", function () {
+      let mockParentOptions = (this.addon.parent.options = {});
       let mockAppOptions = {};
       this.addon.app = { options: mockAppOptions };
 
@@ -1287,319 +1367,452 @@ describe('ember-cli-babel', function() {
     });
   });
 
-  describe('_shouldIncludePolyfill()', function() {
-    describe('without any includePolyfill option set', function() {
-      it('should return false', function() {
+  describe("_shouldIncludePolyfill()", function () {
+    describe("without any includePolyfill option set", function () {
+      it("should return false", function () {
         expect(this.addon._shouldIncludePolyfill()).to.be.false;
       });
 
-      it('should not print deprecation messages', function() {
+      it("should not print deprecation messages", function () {
         this.addon._shouldIncludePolyfill();
 
-        let deprecationMessages = this.ui.output.split('\n').filter(function(line) {
-          return line.indexOf('Putting the "includePolyfill" option in "babel" is deprecated') !== -1;
-        });
+        let deprecationMessages = this.ui.output
+          .split("\n")
+          .filter(function (line) {
+            return (
+              line.indexOf(
+                'Putting the "includePolyfill" option in "babel" is deprecated'
+              ) !== -1
+            );
+          });
 
         expect(deprecationMessages).to.have.lengthOf(0);
       });
     });
 
-    describe('with ember-cli-babel.includePolyfill = true', function() {
-      beforeEach(function() {
-        this.addon.parent.options = { 'ember-cli-babel': { includePolyfill: true } };
+    describe("with ember-cli-babel.includePolyfill = true", function () {
+      beforeEach(function () {
+        this.addon.parent.options = {
+          "ember-cli-babel": { includePolyfill: true },
+        };
       });
 
-      it('should return true', function() {
+      it("should return true", function () {
         expect(this.addon._shouldIncludePolyfill()).to.be.true;
       });
 
-      it('should not print deprecation messages', function() {
+      it("should not print deprecation messages", function () {
         this.addon._shouldIncludePolyfill();
 
-        let deprecationMessages = this.ui.output.split('\n').filter(function(line) {
-          return line.indexOf('Putting the "includePolyfill" option in "babel" is deprecated') !== -1;
-        });
+        let deprecationMessages = this.ui.output
+          .split("\n")
+          .filter(function (line) {
+            return (
+              line.indexOf(
+                'Putting the "includePolyfill" option in "babel" is deprecated'
+              ) !== -1
+            );
+          });
 
         expect(deprecationMessages).to.have.lengthOf(0);
       });
     });
 
-    describe('with ember-cli-babel.includePolyfill = false', function() {
-      beforeEach(function() {
-        this.addon.parent.options = { 'ember-cli-babel': { includePolyfill: false } };
+    describe("with ember-cli-babel.includePolyfill = false", function () {
+      beforeEach(function () {
+        this.addon.parent.options = {
+          "ember-cli-babel": { includePolyfill: false },
+        };
       });
 
-      it('should return false', function() {
+      it("should return false", function () {
         expect(this.addon._shouldIncludePolyfill()).to.be.false;
       });
 
-      it('should not print deprecation messages', function() {
+      it("should not print deprecation messages", function () {
         this.addon._shouldIncludePolyfill();
 
-        let deprecationMessages = this.ui.output.split('\n').filter(function(line) {
-          return line.indexOf('Putting the "includePolyfill" option in "babel" is deprecated') !== -1;
-        });
+        let deprecationMessages = this.ui.output
+          .split("\n")
+          .filter(function (line) {
+            return (
+              line.indexOf(
+                'Putting the "includePolyfill" option in "babel" is deprecated'
+              ) !== -1
+            );
+          });
 
         expect(deprecationMessages).to.have.lengthOf(0);
       });
     });
   });
 
-  describe('_shouldHandleTypeScript', function() {
+  describe("_shouldHandleTypeScript", function () {
     let project;
     let unlink;
 
-    let setupTsAddon = function*(context, version = '4.0.0-alpha.1') {
-      let fixturifyProject = new FixturifyProject('whatever', '0.0.1');
-      fixturifyProject.addDependency('ember-cli-typescript', version, addon => {
-        return prepareAddon(addon);
-      });
-      fixturifyProject.addDependency('ember-cli-babel', 'babel/ember-cli-babel#master');
-      let pkg = JSON.parse(fixturifyProject.toJSON('package.json'));
+    let setupTsAddon = function* (context, version = "4.0.0-alpha.1") {
+      let fixturifyProject = new FixturifyProject("whatever", "0.0.1");
+      fixturifyProject.addDependency(
+        "ember-cli-typescript",
+        version,
+        (addon) => {
+          return prepareAddon(addon);
+        }
+      );
+      fixturifyProject.addDependency(
+        "ember-cli-babel",
+        "babel/ember-cli-babel#master"
+      );
+      let pkg = JSON.parse(fixturifyProject.toJSON("package.json"));
       fixturifyProject.writeSync();
 
-      let linkPath = path.join(fixturifyProject.root, 'whatever/node_modules/ember-cli-babel');
-      let addonPath = path.resolve(__dirname, '../');
+      let linkPath = path.join(
+        fixturifyProject.root,
+        "whatever/node_modules/ember-cli-babel"
+      );
+      let addonPath = path.resolve(__dirname, "../");
       rimraf.sync(linkPath);
-      fs.symlinkSync(addonPath, linkPath, 'junction');
+      fs.symlinkSync(addonPath, linkPath, "junction");
       unlink = () => {
         fs.unlinkSync(linkPath);
       };
 
       let cli = new MockCLI();
-      let root = path.join(fixturifyProject.root, 'whatever');
+      let root = path.join(fixturifyProject.root, "whatever");
       project = new EmberProject(root, pkg, cli.ui, cli);
       project.initializeAddons();
-      context.addon = project.addons.find(a => { return a.name === 'ember-cli-babel'; });
+      context.addon = project.addons.find((a) => {
+        return a.name === "ember-cli-babel";
+      });
       input = yield createTempDir();
-    }
+    };
 
-    afterEach(co.wrap(function*() {
-      if (unlink) {
-        unlink();
-        unlink = undefined;
-      }
+    afterEach(
+      co.wrap(function* () {
+        if (unlink) {
+          unlink();
+          unlink = undefined;
+        }
 
-      // shut down workers after the tests are run so that mocha doesn't hang
-      yield terminateWorkerPool();
-    }));
+        // shut down workers after the tests are run so that mocha doesn't hang
+        yield terminateWorkerPool();
+      })
+    );
 
-    it('should return false by default', function() {
-      expect(_shouldHandleTypeScript({}, this.addon.parent, this.addon.project)).to.be.false;
+    it("should return false by default", function () {
+      expect(_shouldHandleTypeScript({}, this.addon.parent, this.addon.project))
+        .to.be.false;
     });
-    it('should return true when ember-cli-typescript >= 4.0.0-alpha.1 is installed', function*() {
+    it("should return true when ember-cli-typescript >= 4.0.0-alpha.1 is installed", function* () {
       yield setupTsAddon(this);
-      expect(_shouldHandleTypeScript({}, this.addon.parent, this.addon.project)).to.be.true;
+      expect(_shouldHandleTypeScript({}, this.addon.parent, this.addon.project))
+        .to.be.true;
     });
-    it('should return false when ember-cli-typescript < 4.0.0-alpha.1 is installed', function*() {
-      yield setupTsAddon(this, '3.0.0');
-      expect(_shouldHandleTypeScript({}, this.addon.parent, this.addon.project)).to.be.false;
+    it("should return false when ember-cli-typescript < 4.0.0-alpha.1 is installed", function* () {
+      yield setupTsAddon(this, "3.0.0");
+      expect(_shouldHandleTypeScript({}, this.addon.parent, this.addon.project))
+        .to.be.false;
     });
-    it('should return true when the TypeScript transform is manually enabled', function*() {
-      yield setupTsAddon(this, '3.0.0');
-      expect(_shouldHandleTypeScript({ 'ember-cli-babel': { enableTypeScriptTransform: true } }, this.addon.parent, this.addon.project)).to.be.true;
+    it("should return true when the TypeScript transform is manually enabled", function* () {
+      yield setupTsAddon(this, "3.0.0");
+      expect(
+        _shouldHandleTypeScript(
+          { "ember-cli-babel": { enableTypeScriptTransform: true } },
+          this.addon.parent,
+          this.addon.project
+        )
+      ).to.be.true;
     });
 
-    it('should return false when the TypeScript transforms is manually disabled', function() {
-      expect(_shouldHandleTypeScript({ 'ember-cli-babel': { enableTypeScriptTransform: false } }, this.addon.parent, this.addon.project)).to.be.false;
+    it("should return false when the TypeScript transforms is manually disabled", function () {
+      expect(
+        _shouldHandleTypeScript(
+          { "ember-cli-babel": { enableTypeScriptTransform: false } },
+          this.addon.parent,
+          this.addon.project
+        )
+      ).to.be.false;
     });
 
-    it('should return false when the TypeScript transform is manually disabled, even when ember-cli-typescript >= 4.0.0-alpha.1 is installed', function*() {
-      yield setupTsAddon(this, '4.1.0');
-      expect(_shouldHandleTypeScript({ 'ember-cli-babel': { enableTypeScriptTransform: false } }, this.addon.parent, this.addon.project)).to.be.false;
+    it("should return false when the TypeScript transform is manually disabled, even when ember-cli-typescript >= 4.0.0-alpha.1 is installed", function* () {
+      yield setupTsAddon(this, "4.1.0");
+      expect(
+        _shouldHandleTypeScript(
+          { "ember-cli-babel": { enableTypeScriptTransform: false } },
+          this.addon.parent,
+          this.addon.project
+        )
+      ).to.be.false;
     });
   });
 
-  describe('_shouldIncludeHelpers()', function() {
-    beforeEach(function() {
+  describe("_shouldIncludeHelpers()", function () {
+    beforeEach(function () {
       this.addon.app = {
-        options: {}
+        options: {},
       };
     });
 
-    it('should return false without any includeExternalHelpers option set', function() {
+    it("should return false without any includeExternalHelpers option set", function () {
       expect(_shouldIncludeHelpers({}, this.addon)).to.be.false;
     });
 
-    it('should throw an error with ember-cli-babel.includeExternalHelpers = true in parent', function() {
-      this.addon.parent.options = { 'ember-cli-babel': { includeExternalHelpers: true } };
+    it("should throw an error with ember-cli-babel.includeExternalHelpers = true in parent", function () {
+      this.addon.parent.options = {
+        "ember-cli-babel": { includeExternalHelpers: true },
+      };
 
       expect(() => _shouldIncludeHelpers({}, this.addon)).to.throw;
     });
 
-    it('should return true with ember-cli-babel.includeExternalHelpers = true in app and ember-cli-version is high enough', function() {
-      this.addon.pkg = { version: '7.3.0-beta.1' };
+    it("should return true with ember-cli-babel.includeExternalHelpers = true in app and ember-cli-version is high enough", function () {
+      this.addon.pkg = { version: "7.3.0-beta.1" };
 
-      this.addon.app.options = { 'ember-cli-babel': { includeExternalHelpers: true } };
+      this.addon.app.options = {
+        "ember-cli-babel": { includeExternalHelpers: true },
+      };
 
       expect(_shouldIncludeHelpers({}, this.addon)).to.be.true;
     });
 
-    it('should return false when compileModules is false', function() {
-      this.addon.pkg = { version: '7.3.0-beta.1' };
+    it("should return false when compileModules is false", function () {
+      this.addon.pkg = { version: "7.3.0-beta.1" };
 
-      this.addon.app.options = { 'ember-cli-babel': { includeExternalHelpers: true } };
+      this.addon.app.options = {
+        "ember-cli-babel": { includeExternalHelpers: true },
+      };
 
       // precond
       expect(_shouldIncludeHelpers({}, this.addon)).to.be.true;
 
-      expect(_shouldIncludeHelpers({ 'ember-cli-babel': { compileModules: false } }, this.addon)).to.be.false;
+      expect(
+        _shouldIncludeHelpers(
+          { "ember-cli-babel": { compileModules: false } },
+          this.addon
+        )
+      ).to.be.false;
     });
 
-    it('should return false with ember-cli-babel.includeExternalHelpers = true in app and write warn line if ember-cli-version is not high enough', function() {
-      this.addon.project.name = 'dummy';
+    it("should return false with ember-cli-babel.includeExternalHelpers = true in app and write warn line if ember-cli-version is not high enough", function () {
+      this.addon.project.name = "dummy";
       this.addon.project.ui = {
         writeWarnLine(message) {
-          expect(message).to.match(/dummy attempted to include external babel helpers/);
-        }
+          expect(message).to.match(
+            /dummy attempted to include external babel helpers/
+          );
+        },
       };
 
-      this.addon.app.options = { 'ember-cli-babel': { includeExternalHelpers: true } };
+      this.addon.app.options = {
+        "ember-cli-babel": { includeExternalHelpers: true },
+      };
 
       expect(_shouldIncludeHelpers({}, this.addon)).to.be.false;
     });
 
-    it('should return false with ember-cli-babel.includeExternalHelpers = false in host', function() {
-      this.addon.app.options = { 'ember-cli-babel': { includeExternalHelpers: false } };
+    it("should return false with ember-cli-babel.includeExternalHelpers = false in host", function () {
+      this.addon.app.options = {
+        "ember-cli-babel": { includeExternalHelpers: false },
+      };
 
       expect(_shouldIncludeHelpers({}, this.addon)).to.be.false;
     });
 
-    it('should work when the host app does not include ember-cli-babel', function() {
+    it("should work when the host app does not include ember-cli-babel", function () {
       this.addon.project.addons = [];
 
       expect(_shouldIncludeHelpers({}, this.addon)).to.be.false;
     });
 
-    describe('autodetection', function() {
-      it('should return true if @ember-decorators/babel-transforms exists and ember-cli-babel version is high enough', function() {
-        this.addon.pkg = { version: '7.3.0-beta.1' };
+    describe("autodetection", function () {
+      it("should return true if @ember-decorators/babel-transforms exists and ember-cli-babel version is high enough", function () {
+        this.addon.pkg = { version: "7.3.0-beta.1" };
         this.addon.project.addons.push({
           pkg: {
-            name: '@ember-decorators/babel-transforms'
-          }
+            name: "@ember-decorators/babel-transforms",
+          },
         });
 
         expect(_shouldIncludeHelpers({}, this.addon)).to.be.true;
       });
 
-      it('should return false if @ember-decorators/babel-transforms exists and write warn line if ember-cli-version is not high enough', function() {
-        this.addon.project.name = 'dummy';
+      it("should return false if @ember-decorators/babel-transforms exists and write warn line if ember-cli-version is not high enough", function () {
+        this.addon.project.name = "dummy";
         this.addon.project.ui = {
           writeWarnLine(message) {
-            expect(message).to.match(/dummy attempted to include external babel helpers/);
-          }
+            expect(message).to.match(
+              /dummy attempted to include external babel helpers/
+            );
+          },
         };
 
         this.addon.project.addons.push({
           pkg: {
-            name: '@ember-decorators/babel-transforms'
-          }
+            name: "@ember-decorators/babel-transforms",
+          },
         });
 
         expect(_shouldIncludeHelpers({}, this.addon)).to.be.false;
       });
-    })
+    });
   });
 
-  describe('_shouldCompileModules()', function() {
-    beforeEach(function() {
+  describe("_shouldCompileModules()", function () {
+    beforeEach(function () {
       this.addon.parent = {
-        dependencies() { return {}; },
-        options: {}
+        dependencies() {
+          return {};
+        },
+        options: {},
       };
     });
 
-    describe('without any compileModules option set', function() {
-      it('returns false for ember-cli < 2.12', function() {
-        this.addon.project.emberCLIVersion = () => '2.11.1';
+    describe("without any compileModules option set", function () {
+      it("returns false for ember-cli < 2.12", function () {
+        this.addon.project.emberCLIVersion = () => "2.11.1";
 
         expect(this.addon.shouldCompileModules()).to.eql(false);
       });
 
-      it('returns true for ember-cli > 2.12.0-alpha.1', function() {
-        this.addon.project.emberCLIVersion = () => '2.13.0';
+      it("returns true for ember-cli > 2.12.0-alpha.1", function () {
+        this.addon.project.emberCLIVersion = () => "2.13.0";
 
         expect(this.addon.shouldCompileModules()).to.be.true;
       });
 
-      it('does not print deprecation messages', function() {
+      it("does not print deprecation messages", function () {
         this.addon.shouldCompileModules();
 
-        let deprecationMessages = this.ui.output.split('\n').filter(function(line) {
-          return line.indexOf('Putting the "compileModules" option in "babel" is deprecated') !== -1;
-        });
+        let deprecationMessages = this.ui.output
+          .split("\n")
+          .filter(function (line) {
+            return (
+              line.indexOf(
+                'Putting the "compileModules" option in "babel" is deprecated'
+              ) !== -1
+            );
+          });
 
         expect(deprecationMessages).to.have.lengthOf(0);
       });
     });
 
-    describe('with ember-cli-babel.compileModules = true', function() {
-      it('should return true', function() {
-        expect(_shouldCompileModules({
-          'ember-cli-babel': { compileModules: true }
-        }, this.addon.project)).to.eql(true);
+    describe("with ember-cli-babel.compileModules = true", function () {
+      it("should return true", function () {
+        expect(
+          _shouldCompileModules(
+            {
+              "ember-cli-babel": { compileModules: true },
+            },
+            this.addon.project
+          )
+        ).to.eql(true);
       });
 
-      it('should not print deprecation messages', function() {
-        _shouldCompileModules({
-          'ember-cli-babel': { compileModules: true }
-        }, this.addon.project);
+      it("should not print deprecation messages", function () {
+        _shouldCompileModules(
+          {
+            "ember-cli-babel": { compileModules: true },
+          },
+          this.addon.project
+        );
 
-        let deprecationMessages = this.ui.output.split('\n').filter(function(line) {
-          return line.indexOf('Putting the "compileModules" option in "babel" is deprecated') !== -1;
-        });
+        let deprecationMessages = this.ui.output
+          .split("\n")
+          .filter(function (line) {
+            return (
+              line.indexOf(
+                'Putting the "compileModules" option in "babel" is deprecated'
+              ) !== -1
+            );
+          });
 
         expect(deprecationMessages).to.have.lengthOf(0);
       });
     });
 
-    describe('with ember-cli-babel.compileModules = false', function() {
-      beforeEach(function() {
+    describe("with ember-cli-babel.compileModules = false", function () {
+      beforeEach(function () {
         this.addon.parent = {
-          dependencies() { return {}; },
+          dependencies() {
+            return {};
+          },
           options: {
-            'ember-cli-babel': { compileModules: false }
-          }
+            "ember-cli-babel": { compileModules: false },
+          },
         };
       });
 
-      it('should return false', function() {
+      it("should return false", function () {
         expect(this.addon.shouldCompileModules()).to.be.false;
       });
 
-      it('should not print deprecation messages', function() {
+      it("should not print deprecation messages", function () {
         this.addon.shouldCompileModules();
 
-        let deprecationMessages = this.ui.output.split('\n').filter(function(line) {
-          return line.indexOf('Putting the "compileModules" option in "babel" is deprecated') !== -1;
-        });
+        let deprecationMessages = this.ui.output
+          .split("\n")
+          .filter(function (line) {
+            return (
+              line.indexOf(
+                'Putting the "compileModules" option in "babel" is deprecated'
+              ) !== -1
+            );
+          });
 
         expect(deprecationMessages).to.have.lengthOf(0);
       });
     });
   });
 
-  describe('_getExtensions', function() {
-    it('defaults to js only', function() {
-      expect(_getExtensions({}, this.addon.parent, this.addon.project)).to.have.members(['js']);
+  describe("_getExtensions", function () {
+    it("defaults to js only", function () {
+      expect(
+        _getExtensions({}, this.addon.parent, this.addon.project)
+      ).to.have.members(["js"]);
     });
-    it('adds ts automatically', function() {
-      this.addon._shouldHandleTypeScript = function() { return true; }
-      expect(_getExtensions({ 'ember-cli-babel': { enableTypeScriptTransform: true } }, this.addon.parent, this.addon.project)).to.have.members(['js', 'ts']);
+    it("adds ts automatically", function () {
+      this.addon._shouldHandleTypeScript = function () {
+        return true;
+      };
+      expect(
+        _getExtensions(
+          { "ember-cli-babel": { enableTypeScriptTransform: true } },
+          this.addon.parent,
+          this.addon.project
+        )
+      ).to.have.members(["js", "ts"]);
     });
-    it('respects user-configured extensions', function() {
-      expect(_getExtensions({ 'ember-cli-babel': { extensions: ['coffee'] } }, this.addon.parent, this.addon.project)).to.have.members(['coffee']);
+    it("respects user-configured extensions", function () {
+      expect(
+        _getExtensions(
+          { "ember-cli-babel": { extensions: ["coffee"] } },
+          this.addon.parent,
+          this.addon.project
+        )
+      ).to.have.members(["coffee"]);
     });
-    it('respects user-configured extensions even when adding TS plugin', function() {
-      expect(_getExtensions({ 'ember-cli-babel': { enableTypeScriptTransform: true, extensions: ['coffee'] } }, this.addon.parent, this.addon.project)).to.have.members(['coffee']);
+    it("respects user-configured extensions even when adding TS plugin", function () {
+      expect(
+        _getExtensions(
+          {
+            "ember-cli-babel": {
+              enableTypeScriptTransform: true,
+              extensions: ["coffee"],
+            },
+          },
+          this.addon.parent,
+          this.addon.project
+        )
+      ).to.have.members(["coffee"]);
     });
   });
 
-  describe('_buildBroccoliBabelTranspilerOptions', function() {
+  describe("_buildBroccoliBabelTranspilerOptions", function () {
     this.timeout(0);
 
-    it('disables reading `.babelrc`', function() {
+    it("disables reading `.babelrc`", function () {
       let options = {};
 
       let result = this.addon._buildBroccoliBabelTranspilerOptions(options);
@@ -1607,47 +1820,51 @@ describe('ember-cli-babel', function() {
       expect(result.babelrc).to.be.false;
     });
 
-    it('provides an annotation including parent name - addon', function() {
+    it("provides an annotation including parent name - addon", function () {
       this.addon.parent = Object.assign({}, this.addon.parent, {
-        name: 'derpy-herpy',
-        dependencies() { return {}; },
+        name: "derpy-herpy",
+        dependencies() {
+          return {};
+        },
       });
       let result = this.addon._buildBroccoliBabelTranspilerOptions();
-      expect(result.annotation).to.include('derpy-herpy');
+      expect(result.annotation).to.include("derpy-herpy");
     });
 
-    it('provides an annotation including parent name - project', function() {
+    it("provides an annotation including parent name - project", function () {
       this.addon.parent = Object.assign({}, this.addon.parent, {
-        name: 'derpy-herpy',
-        dependencies() { return {}; },
+        name: "derpy-herpy",
+        dependencies() {
+          return {};
+        },
       });
       let result = this.addon._buildBroccoliBabelTranspilerOptions();
-      expect(result.annotation).to.include('derpy-herpy');
+      expect(result.annotation).to.include("derpy-herpy");
     });
 
-    it('uses provided annotation if specified', function() {
+    it("uses provided annotation if specified", function () {
       let options = {
-        'ember-cli-babel': {
-          annotation: 'Hello World!'
-        }
+        "ember-cli-babel": {
+          annotation: "Hello World!",
+        },
       };
 
       let result = this.addon._buildBroccoliBabelTranspilerOptions(options);
-      expect(result.annotation).to.equal('Hello World!');
+      expect(result.annotation).to.equal("Hello World!");
     });
 
-    it('uses provided sourceMaps if specified', function() {
+    it("uses provided sourceMaps if specified", function () {
       let options = {
         babel: {
-          sourceMaps: 'inline'
-        }
+          sourceMaps: "inline",
+        },
       };
 
       let result = this.addon._buildBroccoliBabelTranspilerOptions(options);
-      expect(result.sourceMaps).to.equal('inline');
+      expect(result.sourceMaps).to.equal("inline");
     });
 
-    it('disables reading `.babelrc`', function() {
+    it("disables reading `.babelrc`", function () {
       let options = {};
 
       let result = this.addon._buildBroccoliBabelTranspilerOptions(options);
@@ -1656,10 +1873,10 @@ describe('ember-cli-babel', function() {
     });
   });
 
-  describe('buildBabelOptions', function() {
+  describe("buildBabelOptions", function () {
     this.timeout(0);
 
-    it('returns broccoli-babel-transpiler options by default', function() {
+    it("returns broccoli-babel-transpiler options by default", function () {
       let result = this.addon.buildBabelOptions();
 
       expect(result.moduleIds).to.be.true;
@@ -1668,8 +1885,8 @@ describe('ember-cli-babel', function() {
       expect(result.configFile).to.be.false;
     });
 
-    it('returns broccoli-babel-transpiler options when asked for', function() {
-      let result = this.addon.buildBabelOptions('broccoli');
+    it("returns broccoli-babel-transpiler options when asked for", function () {
+      let result = this.addon.buildBabelOptions("broccoli");
 
       expect(result.moduleIds).to.be.true;
       expect(result.annotation).to.be;
@@ -1677,43 +1894,45 @@ describe('ember-cli-babel', function() {
       expect(result.configFile).to.be.false;
     });
 
-    it('returns broccoli-babel-transpiler options with customizations when provided', function() {
-      let result = this.addon.buildBabelOptions('broccoli', {
-        'ember-cli-babel': {
-          annotation: 'hello!!!',
-        }
+    it("returns broccoli-babel-transpiler options with customizations when provided", function () {
+      let result = this.addon.buildBabelOptions("broccoli", {
+        "ember-cli-babel": {
+          annotation: "hello!!!",
+        },
       });
 
-      expect(result.annotation).to.equal('hello!!!');
+      expect(result.annotation).to.equal("hello!!!");
       expect(result.moduleIds).to.be.true;
       expect(result.annotation).to.be;
       expect(result.babelrc).to.be.false;
       expect(result.configFile).to.be.false;
     });
 
-    it('returns babel options when asked for', function() {
-      let result = this.addon.buildBabelOptions('babel');
+    it("returns babel options when asked for", function () {
+      let result = this.addon.buildBabelOptions("babel");
 
-      expect('moduleIds' in result).to.be.false;
-      expect('annotation' in result).to.be.false;
-      expect('babelrc' in result).to.be.false;
-      expect('configFile' in result).to.be.false;
+      expect("moduleIds" in result).to.be.false;
+      expect("annotation" in result).to.be.false;
+      expect("babelrc" in result).to.be.false;
+      expect("configFile" in result).to.be.false;
     });
 
-    it('does not include all provided options', function() {
+    it("does not include all provided options", function () {
       let babelOptions = { blah: true };
       let options = {
-        babel: babelOptions
+        babel: babelOptions,
       };
 
-      let result = this.addon.buildBabelOptions('babel', options);
+      let result = this.addon.buildBabelOptions("babel", options);
       expect(result.blah).to.be.undefined;
     });
 
-    it('does not include all provided options', function() {
+    it("does not include all provided options", function () {
       let babelOptions = { blah: true };
       this.addon.parent = Object.assign({}, this.addon.parent, {
-        dependencies() { return {}; },
+        dependencies() {
+          return {};
+        },
         options: {
           babel: babelOptions,
         },
@@ -1723,13 +1942,15 @@ describe('ember-cli-babel', function() {
       expect(result.blah).to.be.undefined;
     });
 
-    it('includes user plugins in parent.options.babel.plugins', function() {
+    it("includes user plugins in parent.options.babel.plugins", function () {
       let plugin = {};
       this.addon.parent = Object.assign({}, this.addon.parent, {
-        dependencies() { return {}; },
+        dependencies() {
+          return {};
+        },
         options: {
           babel: {
-            plugins: [ plugin ]
+            plugins: [plugin],
           },
         },
       });
@@ -1738,15 +1959,17 @@ describe('ember-cli-babel', function() {
       expect(result.plugins).to.deep.include(plugin);
     });
 
-    it('includes postTransformPlugins after preset-env plugins', function() {
+    it("includes postTransformPlugins after preset-env plugins", function () {
       let plugin = {};
       let pluginAfter = {};
       this.addon.parent = Object.assign({}, this.addon.parent, {
-        dependencies() { return {}; },
+        dependencies() {
+          return {};
+        },
         options: {
           babel: {
-            plugins: [ plugin ],
-            postTransformPlugins: [ pluginAfter ]
+            plugins: [plugin],
+            postTransformPlugins: [pluginAfter],
           },
         },
       });
@@ -1758,17 +1981,19 @@ describe('ember-cli-babel', function() {
       expect(result.postTransformPlugins).to.be.undefined;
     });
 
-    it('sets `presets` to empty array if `disablePresetEnv` is true', function() {
+    it("sets `presets` to empty array if `disablePresetEnv` is true", function () {
       let options = {
-        'ember-cli-babel': {
+        "ember-cli-babel": {
           disablePresetEnv: true,
-        }
+        },
       };
       this.addon.parent = Object.assign({}, this.addon.parent, {
-        dependencies() { return {}; },
+        dependencies() {
+          return {};
+        },
         options: {
           babel6: {
-            plugins: [ {} ]
+            plugins: [{}],
           },
         },
       });
@@ -1777,13 +2002,15 @@ describe('ember-cli-babel', function() {
       expect(result.presets).to.deep.equal([]);
     });
 
-    it('user plugins are before preset-env plugins', function() {
+    it("user plugins are before preset-env plugins", function () {
       let plugin = function Plugin() {};
       this.addon.parent = Object.assign({}, this.addon.parent, {
-        dependencies() { return {}; },
+        dependencies() {
+          return {};
+        },
         options: {
           babel: {
-            plugins: [ plugin ]
+            plugins: [plugin],
           },
         },
       });
@@ -1792,58 +2019,58 @@ describe('ember-cli-babel', function() {
       expect(result.plugins[0]).to.equal(plugin);
     });
 
-    it('includes resolveModuleSource if compiling modules', function() {
-
-      let expectedPlugin = require.resolve('babel-plugin-module-resolver');
+    it("includes resolveModuleSource if compiling modules", function () {
+      let expectedPlugin = require.resolve("babel-plugin-module-resolver");
 
       let result = this.addon.buildBabelOptions({
-        'ember-cli-babel': {
+        "ember-cli-babel": {
           compileModules: true,
-        }
+        },
       });
-      let found = result.plugins.find(plugin => plugin[0] === expectedPlugin);
+      let found = result.plugins.find((plugin) => plugin[0] === expectedPlugin);
 
-      expect(typeof found[1].resolvePath).to.equal('function');
+      expect(typeof found[1].resolvePath).to.equal("function");
     });
 
-    it('does not include resolveModuleSource when not compiling modules', function() {
-
-      let expectedPlugin = require('babel-plugin-module-resolver').default;
+    it("does not include resolveModuleSource when not compiling modules", function () {
+      let expectedPlugin = require("babel-plugin-module-resolver").default;
 
       let result = this.addon.buildBabelOptions({
-        'ember-cli-babel': {
+        "ember-cli-babel": {
           compileModules: false,
-        }
+        },
       });
-      let found = result.plugins.find(plugin => plugin[0] === expectedPlugin);
+      let found = result.plugins.find((plugin) => plugin[0] === expectedPlugin);
 
       expect(found).to.equal(undefined);
     });
   });
 
-  describe('_getPresetEnv', function() {
+  describe("_getPresetEnv", function () {
     this.timeout(5000);
 
-    it('does nothing when disablePresetEnv is set', function() {
+    it("does nothing when disablePresetEnv is set", function () {
       let _presetEnvCalled = false;
 
-      this.addon._presetEnv = function() {
+      this.addon._presetEnv = function () {
         _presetEnvCalled = true;
       };
 
       this.addon.buildBabelOptions({
-        'ember-cli-babel': {
+        "ember-cli-babel": {
           disablePresetEnv: true,
-        }
+        },
       });
 
       expect(_presetEnvCalled).to.be.false;
     });
 
-    it('passes options.babel through to preset-env', function() {
+    it("passes options.babel through to preset-env", function () {
       let babelOptions = { loose: true };
       this.addon.parent = Object.assign({}, this.addon.parent, {
-        dependencies() { return {}; },
+        dependencies() {
+          return {};
+        },
         options: {
           babel: babelOptions,
         },
@@ -1852,54 +2079,75 @@ describe('ember-cli-babel', function() {
       let options = this.addon.buildBabelOptions();
 
       expect(options.presets).to.deep.equal([
-        [require.resolve('@babel/preset-env'), {
-          loose: true,
-          modules: false,
-          targets: { browsers: ['ie 11'] },
-        }],
+        [
+          require.resolve("@babel/preset-env"),
+          {
+            loose: true,
+            modules: false,
+            targets: { browsers: ["ie 11"] },
+          },
+        ],
       ]);
     });
   });
 
-  describe('isPluginRequired', function() {
-    it('returns true when no targets are specified', function() {
+  describe("isPluginRequired", function () {
+    it("returns true when no targets are specified", function () {
       this.addon.project.targets = null;
 
-      let pluginRequired = this.addon.isPluginRequired('transform-regenerator');
+      let pluginRequired = this.addon.isPluginRequired("transform-regenerator");
       expect(pluginRequired).to.be.true;
     });
 
-    it('returns true when targets require plugin', function() {
+    it("returns true when targets require plugin", function () {
       this.addon.project.targets = {
-        browsers: ['ie 9']
+        browsers: ["ie 9"],
       };
 
-      let pluginRequired = this.addon.isPluginRequired('transform-regenerator');
+      let pluginRequired = this.addon.isPluginRequired("transform-regenerator");
       expect(pluginRequired).to.be.true;
     });
 
-    it('returns false when targets do not require plugin', function() {
+    it("returns false when targets do not require plugin", function () {
       this.addon.project.targets = {
-        browsers: ['last 2 chrome versions']
+        browsers: ["last 2 chrome versions"],
       };
 
-      let pluginRequired = this.addon.isPluginRequired('transform-regenerator');
+      let pluginRequired = this.addon.isPluginRequired("transform-regenerator");
       expect(pluginRequired).to.be.false;
     });
 
-    it('defensively copies `targets` to prevent @babel/helper-compilation-functions mutating it', function() {
+    it("defensively copies `targets` to prevent @babel/helper-compilation-functions mutating it", function () {
       let targets = {
-        browsers: ['last 2 Chrome versions']
+        browsers: ["last 2 Chrome versions"],
       };
       this.addon.project.targets = clone(targets);
 
-      this.addon.isPluginRequired('transform-regenerator');
+      this.addon.isPluginRequired("transform-regenerator");
       expect(this.addon.project.targets).to.deep.equal(targets);
     });
+
+    it("returns `true` for proposal-class-properties when IE11 is in targets", function () {
+      this.addon.project.targets = {
+        browsers: ["ie 11"],
+      };
+
+      expect(this.addon.isPluginRequired("proposal-class-properties")).to.be
+        .true;
+    });
+
+    it("returns `false` for proposal-class-properties when using latest evergreens", function () {
+      this.addon.project.targets = {
+        browsers: ["Last 2 Chrome versions"],
+      };
+
+      expect(this.addon.isPluginRequired("proposal-class-properties")).to.be
+        .false;
+    });
   });
 });
 
-describe('EmberData Packages Polyfill', function() {
+describe("EmberData Packages Polyfill", function () {
   this.timeout(0);
 
   let input;
@@ -1909,300 +2157,224 @@ describe('EmberData Packages Polyfill', function() {
   let project;
   let unlink;
 
-  beforeEach(function() {
+  beforeEach(function () {
     let self = this;
-    setupForVersion = co.wrap(function*(v) {
-      let fixturifyProject = new FixturifyProject('whatever', '0.0.1');
-      fixturifyProject.addDependency('ember-data', v, addon => {
+    setupForVersion = co.wrap(function* (v) {
+      let fixturifyProject = new FixturifyProject("whatever", "0.0.1");
+      fixturifyProject.addDependency("ember-data", v, (addon) => {
         return prepareAddon(addon);
       });
-      fixturifyProject.addDependency('ember-cli-babel', 'babel/ember-cli-babel#master');
-      fixturifyProject.addDependency('random-addon', '0.0.1', addon => {
+      fixturifyProject.addDependency(
+        "ember-cli-babel",
+        "babel/ember-cli-babel#master"
+      );
+      fixturifyProject.addDependency("random-addon", "0.0.1", (addon) => {
         return prepareAddon(addon);
       });
-      let pkg = JSON.parse(fixturifyProject.toJSON('package.json'));
+      let pkg = JSON.parse(fixturifyProject.toJSON("package.json"));
       fixturifyProject.writeSync();
 
-      let linkPath = path.join(fixturifyProject.root, '/whatever/node_modules/ember-cli-babel');
-      let addonPath = path.resolve(__dirname, '../');
+      let linkPath = path.join(
+        fixturifyProject.root,
+        "/whatever/node_modules/ember-cli-babel"
+      );
+      let addonPath = path.resolve(__dirname, "../");
       rimraf.sync(linkPath);
-      fs.symlinkSync(addonPath, linkPath, 'junction');
+      fs.symlinkSync(addonPath, linkPath, "junction");
       unlink = () => {
         fs.unlinkSync(linkPath);
       };
 
       let cli = new MockCLI();
-      let root = path.join(fixturifyProject.root, 'whatever');
+      let root = path.join(fixturifyProject.root, "whatever");
       project = new EmberProject(root, pkg, cli.ui, cli);
       project.initializeAddons();
 
-      self.addon = project.addons.find(a => { return a.name === 'ember-cli-babel'; });
+      self.addon = project.addons.find((a) => {
+        return a.name === "ember-cli-babel";
+      });
 
       input = yield createTempDir();
     });
   });
 
-  afterEach(co.wrap(function*() {
-    unlink();
+  afterEach(
+    co.wrap(function* () {
+      unlink();
 
-    if (input) {
-      yield input.dispose();
-    }
-
-    if (output) {
-      yield output.dispose();
-    }
-
-    // shut down workers after the tests are run so that mocha doesn't hang
-    yield terminateWorkerPool();
-  }));
-
-  it("does not convert when _emberDataVersionRequiresPackagesPolyfill returns false", co.wrap(function*() {
-    yield setupForVersion('3.12.0-alpha.0');
-    input.write({
-      "foo.js": `export { default } from '@ember-data/store';`,
-      "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;\nexport var name = attr;`,
-    });
-
-    subject = this.addon.transpileTree(input.path(), {
-      'ember-cli-babel': {
-        compileModules: false,
-        disableDebugTooling: true,
-        disableEmberDataPackagesPolyfill: true
+      if (input) {
+        yield input.dispose();
       }
-    });
 
-    output = createBuilder(subject);
-
-    yield output.build();
-
-    expect(
-      output.read()
-    ).to.deep.equal({
-      "foo.js": `export { default } from '@ember-data/store';`,
-      "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;\nexport var name = attr;`,
-    });
-  }));
-
-  it("does not convert for EmberData when _emberDataVersionRequiresPackagesPolyfill returns true and disableEmberDataPackagesPolyfill is true", co.wrap(function*() {
-    yield setupForVersion('3.11.0');
-    input.write({
-      "foo.js": `export { default } from '@ember-data/store';`,
-      "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;\nexport var name = attr;`,
-    });
-
-    subject = this.addon.transpileTree(input.path(), {
-      'ember-cli-babel': {
-        compileModules: false,
-        disableDebugTooling: true,
-        disableEmberDataPackagesPolyfill: true
+      if (output) {
+        yield output.dispose();
       }
-    });
 
-    output = createBuilder(subject);
+      // shut down workers after the tests are run so that mocha doesn't hang
+      yield terminateWorkerPool();
+    })
+  );
 
-    yield output.build();
-
-    expect(
-      output.read()
-    ).to.deep.equal({
-      "foo.js": `export { default } from '@ember-data/store';`,
-      "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;\nexport var name = attr;`,
-    });
-  }));
-
-  it("it does convert for EmberData when _emberDataVersionRequiresPackagesPolyfill returns true", co.wrap(function*() {
-    yield setupForVersion('3.11.99');
-    input.write({
-      "foo.js": `export { default } from '@ember-data/store';`,
-      "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;export var name = attr;`,
-    });
-
-    subject = this.addon.transpileTree(input.path(), {
-      'ember-cli-babel': {
-        compileModules: false,
-        disableDebugTooling: true,
-      }
-    });
-
-    output = createBuilder(subject);
-
-    yield output.build();
-
-    expect(
-      output.read()
-    ).to.deep.equal({
-      "foo.js": `import DS from "ember-data";\nexport default DS.Store;`,
-      "bar.js": `import DS from "ember-data";\nvar Model = DS.Model;\nvar attr = DS.attr;\nexport var User = Model;\nexport var name = attr;`,
-    });
-  }));
-
-  it("conversion works with compilation to AMD modules", co.wrap(function*() {
-    yield setupForVersion('3.11.99');
-    input.write({
-      "foo.js": `export { default } from '@ember-data/store';`,
-      "bem.js": `export { default } from 'ember-data';`,
-      "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;export var name = attr;`,
-      "baz.js": `import EmberData from 'ember-data';\nexport var User = EmberData.Model;`,
-    });
-
-    subject = this.addon.transpileTree(input.path(), {
-      'ember-cli-babel': {
-        compileModules: true,
-        disableDebugTooling: true,
-      }
-    });
-
-    output = createBuilder(subject);
-
-    yield output.build();
-
-   function moduleOutput(moduleName, transpiledModuleBodyCode) {
-     return `define("${moduleName}", ["exports", "ember-data"], function (_exports, _emberData) {\n  "use strict";\n\n  Object.defineProperty(_exports, "__esModule", {\n    value: true\n  });\n${transpiledModuleBodyCode}\n});`
-   }
-
-   let fooOutput = moduleOutput(
-     'foo',
-      assembleLines([
-        `_exports.default = void 0;`,
-        `var _default = _emberData.default.Store;`,
-        `_exports.default = _default;`
-      ])
-    );
-   let bemOutput = moduleOutput(
-     'bem',
-     assembleLines([
-       `Object.defineProperty(_exports, "default", {`,
-       `  enumerable: true,`,
-       `  get: function get() {`,
-       `    return _emberData.default;`,
-       `  }`,
-       `});`
-     ])
-   );
-   let barOutput = moduleOutput(
-     'bar',
-     assembleLines([
-      `_exports.name = _exports.User = void 0;`,
-      `var Model = _emberData.default.Model;`,
-      `var attr = _emberData.default.attr;`,
-      `var User = Model;`,
-      `_exports.User = User;`,
-      `var name = attr;`,
-      `_exports.name = name;`
-     ])
-    );
-   let bazOutput = moduleOutput(
-     'baz',
-     assembleLines([
-       `_exports.User = void 0;`,
-       `var EmberData = _emberData.default;`,
-       `var User = EmberData.Model;`,
-       `_exports.User = User;`
-     ])
-   );
-
-   let transpiled = output.read();
-    expect(transpiled['foo.js']).to.equal(fooOutput);
-    expect(transpiled['bem.js']).to.equal(bemOutput);
-    expect(transpiled['bar.js']).to.equal(barOutput);
-    expect(transpiled['baz.js']).to.equal(bazOutput);
-  }));
-});
-
-describe('EmberData Packages Polyfill - ember-cli-babel for ember-data', function() {
-  this.timeout(0);
-
-  let input;
-  let output;
-  let subject;
-  let setupForVersion;
-  let project;
-  let unlink;
-
-  beforeEach(function() {
-    let self = this;
-    setupForVersion = co.wrap(function*(p, v) {
-      let fixturifyProject = new FixturifyProject('whatever', '0.0.1');
-      let emberDataFixture = fixturifyProject.addDependency(p, v, addon => {
-        return prepareAddon(addon);
-      });
-      emberDataFixture.addDependency('ember-cli-babel', 'babel/ember-cli-babel#master');
-      fixturifyProject.addDependency('random-addon', '0.0.1', addon => {
-        return prepareAddon(addon);
-      });
-      let pkg = JSON.parse(fixturifyProject.toJSON('package.json'));
-      fixturifyProject.writeSync();
-
-      let linkPath = path.join(fixturifyProject.root, `/whatever/node_modules/${p}/node_modules/ember-cli-babel`);
-      let addonPath = path.resolve(__dirname, '../');
-      rimraf.sync(linkPath);
-      fs.symlinkSync(addonPath, linkPath, 'junction');
-      unlink = () => {
-        fs.unlinkSync(linkPath);
-      };
-
-      let cli = new MockCLI();
-      let root = path.join(fixturifyProject.root, 'whatever');
-      project = new EmberProject(root, pkg, cli.ui, cli);
-      project.initializeAddons();
-
-      self.emberDataAddon = project.addons.find(a => { return a.name === p; });
-      self.emberDataAddon.initializeAddons();
-      self.addon = self.emberDataAddon.addons.find(a => { return a.name === 'ember-cli-babel'; });
-
-      input = yield createTempDir();
-    });
-  });
-
-  afterEach(co.wrap(function*() {
-    unlink();
-
-    if (input) {
-      yield input.dispose();
-    }
-
-    if (output) {
-      yield output.dispose();
-    }
-
-    // shut down workers after the tests are run so that mocha doesn't hang
-    yield terminateWorkerPool();
-  }));
-
-  ['ember-data', '@ember-data/store'].forEach(parentDep => {
-    it(`does not convert when compiling ${parentDep} itself`, co.wrap(function*() {
-      yield setupForVersion(parentDep, '3.10.0');
-
+  it(
+    "does not convert when _emberDataVersionRequiresPackagesPolyfill returns false",
+    co.wrap(function* () {
+      yield setupForVersion("3.12.0-alpha.0");
       input.write({
         "foo.js": `export { default } from '@ember-data/store';`,
         "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;\nexport var name = attr;`,
-        "bem.js": `export { AdapterError } from 'ember-data/-private';`,
       });
 
       subject = this.addon.transpileTree(input.path(), {
-        'ember-cli-babel': {
+        "ember-cli-babel": {
           compileModules: false,
           disableDebugTooling: true,
-        }
+          disableEmberDataPackagesPolyfill: true,
+        },
       });
 
       output = createBuilder(subject);
 
       yield output.build();
 
-      expect(
-        output.read()
-      ).to.deep.equal({
+      expect(output.read()).to.deep.equal({
         "foo.js": `export { default } from '@ember-data/store';`,
         "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;\nexport var name = attr;`,
-        "bem.js": `export { AdapterError } from 'ember-data/-private';`,
       });
-    }));
-  });
+    })
+  );
+
+  it(
+    "does not convert for EmberData when _emberDataVersionRequiresPackagesPolyfill returns true and disableEmberDataPackagesPolyfill is true",
+    co.wrap(function* () {
+      yield setupForVersion("3.11.0");
+      input.write({
+        "foo.js": `export { default } from '@ember-data/store';`,
+        "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;\nexport var name = attr;`,
+      });
+
+      subject = this.addon.transpileTree(input.path(), {
+        "ember-cli-babel": {
+          compileModules: false,
+          disableDebugTooling: true,
+          disableEmberDataPackagesPolyfill: true,
+        },
+      });
+
+      output = createBuilder(subject);
+
+      yield output.build();
+
+      expect(output.read()).to.deep.equal({
+        "foo.js": `export { default } from '@ember-data/store';`,
+        "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;\nexport var name = attr;`,
+      });
+    })
+  );
+
+  it(
+    "it does convert for EmberData when _emberDataVersionRequiresPackagesPolyfill returns true",
+    co.wrap(function* () {
+      yield setupForVersion("3.11.99");
+      input.write({
+        "foo.js": `export { default } from '@ember-data/store';`,
+        "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;export var name = attr;`,
+      });
+
+      subject = this.addon.transpileTree(input.path(), {
+        "ember-cli-babel": {
+          compileModules: false,
+          disableDebugTooling: true,
+        },
+      });
+
+      output = createBuilder(subject);
+
+      yield output.build();
+
+      expect(output.read()).to.deep.equal({
+        "foo.js": `import DS from "ember-data";\nexport default DS.Store;`,
+        "bar.js": `import DS from "ember-data";\nvar Model = DS.Model;\nvar attr = DS.attr;\nexport var User = Model;\nexport var name = attr;`,
+      });
+    })
+  );
+
+  it(
+    "conversion works with compilation to AMD modules",
+    co.wrap(function* () {
+      yield setupForVersion("3.11.99");
+      input.write({
+        "foo.js": `export { default } from '@ember-data/store';`,
+        "bem.js": `export { default } from 'ember-data';`,
+        "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;export var name = attr;`,
+        "baz.js": `import EmberData from 'ember-data';\nexport var User = EmberData.Model;`,
+      });
+
+      subject = this.addon.transpileTree(input.path(), {
+        "ember-cli-babel": {
+          compileModules: true,
+          disableDebugTooling: true,
+        },
+      });
+
+      output = createBuilder(subject);
+
+      yield output.build();
+
+      function moduleOutput(moduleName, transpiledModuleBodyCode) {
+        return `define("${moduleName}", ["exports", "ember-data"], function (_exports, _emberData) {\n  "use strict";\n\n  Object.defineProperty(_exports, "__esModule", {\n    value: true\n  });\n${transpiledModuleBodyCode}\n});`;
+      }
+
+      let fooOutput = moduleOutput(
+        "foo",
+        assembleLines([
+          `_exports.default = void 0;`,
+          `var _default = _emberData.default.Store;`,
+          `_exports.default = _default;`,
+        ])
+      );
+      let bemOutput = moduleOutput(
+        "bem",
+        assembleLines([
+          `Object.defineProperty(_exports, "default", {`,
+          `  enumerable: true,`,
+          `  get: function get() {`,
+          `    return _emberData.default;`,
+          `  }`,
+          `});`,
+        ])
+      );
+      let barOutput = moduleOutput(
+        "bar",
+        assembleLines([
+          `_exports.name = _exports.User = void 0;`,
+          `var Model = _emberData.default.Model;`,
+          `var attr = _emberData.default.attr;`,
+          `var User = Model;`,
+          `_exports.User = User;`,
+          `var name = attr;`,
+          `_exports.name = name;`,
+        ])
+      );
+      let bazOutput = moduleOutput(
+        "baz",
+        assembleLines([
+          `_exports.User = void 0;`,
+          `var EmberData = _emberData.default;`,
+          `var User = EmberData.Model;`,
+          `_exports.User = User;`,
+        ])
+      );
+
+      let transpiled = output.read();
+      expect(transpiled["foo.js"]).to.equal(fooOutput);
+      expect(transpiled["bem.js"]).to.equal(bemOutput);
+      expect(transpiled["bar.js"]).to.equal(barOutput);
+      expect(transpiled["baz.js"]).to.equal(bazOutput);
+    })
+  );
 });
 
-describe('babel config file', function() {
+describe("EmberData Packages Polyfill - ember-cli-babel for ember-data", function () {
   this.timeout(0);
 
   let input;
@@ -2212,18 +2384,127 @@ describe('babel config file', function() {
   let project;
   let unlink;
 
-  beforeEach(function() {
+  beforeEach(function () {
     let self = this;
-    setupForVersion = co.wrap(function*(plugins) {
-      let fixturifyProject = new FixturifyProject('whatever', '0.0.1');
-
-      fixturifyProject.addDependency('ember-cli-babel', 'babel/ember-cli-babel#master');
-      fixturifyProject.addDependency('random-addon', '0.0.1', addon => {
+    setupForVersion = co.wrap(function* (p, v) {
+      let fixturifyProject = new FixturifyProject("whatever", "0.0.1");
+      let emberDataFixture = fixturifyProject.addDependency(p, v, (addon) => {
         return prepareAddon(addon);
       });
-      let pkg = JSON.parse(fixturifyProject.toJSON('package.json'));
-      fixturifyProject.files['babel.config.js'] =
-      `module.exports = function (api) {
+      emberDataFixture.addDependency(
+        "ember-cli-babel",
+        "babel/ember-cli-babel#master"
+      );
+      fixturifyProject.addDependency("random-addon", "0.0.1", (addon) => {
+        return prepareAddon(addon);
+      });
+      let pkg = JSON.parse(fixturifyProject.toJSON("package.json"));
+      fixturifyProject.writeSync();
+
+      let linkPath = path.join(
+        fixturifyProject.root,
+        `/whatever/node_modules/${p}/node_modules/ember-cli-babel`
+      );
+      let addonPath = path.resolve(__dirname, "../");
+      rimraf.sync(linkPath);
+      fs.symlinkSync(addonPath, linkPath, "junction");
+      unlink = () => {
+        fs.unlinkSync(linkPath);
+      };
+
+      let cli = new MockCLI();
+      let root = path.join(fixturifyProject.root, "whatever");
+      project = new EmberProject(root, pkg, cli.ui, cli);
+      project.initializeAddons();
+
+      self.emberDataAddon = project.addons.find((a) => {
+        return a.name === p;
+      });
+      self.emberDataAddon.initializeAddons();
+      self.addon = self.emberDataAddon.addons.find((a) => {
+        return a.name === "ember-cli-babel";
+      });
+
+      input = yield createTempDir();
+    });
+  });
+
+  afterEach(
+    co.wrap(function* () {
+      unlink();
+
+      if (input) {
+        yield input.dispose();
+      }
+
+      if (output) {
+        yield output.dispose();
+      }
+
+      // shut down workers after the tests are run so that mocha doesn't hang
+      yield terminateWorkerPool();
+    })
+  );
+
+  ["ember-data", "@ember-data/store"].forEach((parentDep) => {
+    it(
+      `does not convert when compiling ${parentDep} itself`,
+      co.wrap(function* () {
+        yield setupForVersion(parentDep, "3.10.0");
+
+        input.write({
+          "foo.js": `export { default } from '@ember-data/store';`,
+          "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;\nexport var name = attr;`,
+          "bem.js": `export { AdapterError } from 'ember-data/-private';`,
+        });
+
+        subject = this.addon.transpileTree(input.path(), {
+          "ember-cli-babel": {
+            compileModules: false,
+            disableDebugTooling: true,
+          },
+        });
+
+        output = createBuilder(subject);
+
+        yield output.build();
+
+        expect(output.read()).to.deep.equal({
+          "foo.js": `export { default } from '@ember-data/store';`,
+          "bar.js": `import Model, { attr } from '@ember-data/model';\nexport var User = Model;\nexport var name = attr;`,
+          "bem.js": `export { AdapterError } from 'ember-data/-private';`,
+        });
+      })
+    );
+  });
+});
+
+describe("babel config file", function () {
+  this.timeout(0);
+
+  let input;
+  let output;
+  let subject;
+  let setupForVersion;
+  let project;
+  let unlink;
+
+  beforeEach(function () {
+    let self = this;
+    setupForVersion = co.wrap(function* (plugins) {
+      let fixturifyProject = new FixturifyProject("whatever", "0.0.1");
+
+      fixturifyProject.addDependency(
+        "ember-cli-babel",
+        "babel/ember-cli-babel#master"
+      );
+      fixturifyProject.addDependency("random-addon", "0.0.1", (addon) => {
+        return prepareAddon(addon);
+      });
+      let pkg = JSON.parse(fixturifyProject.toJSON("package.json"));
+      fixturifyProject.files[
+        "babel.config.js"
+      ] = `module.exports = function (api) {
         api.cache(true);
         return {
           plugins: [
@@ -2232,7 +2513,11 @@ describe('babel config file', function() {
         };
       };
       `;
-      const packageDir = path.dirname(require.resolve(path.join("@babel/plugin-transform-modules-amd", 'package.json')));
+      const packageDir = path.dirname(
+        require.resolve(
+          path.join("@babel/plugin-transform-modules-amd", "package.json")
+        )
+      );
       // symlink the "@babel/plugin-transform-modules-amd" dependency into the project
       // TODO: Move this function out so that it can be used by other tests in the future.
       const writeSync = function () {
@@ -2260,22 +2545,27 @@ describe('babel config file', function() {
         }
       };
 
-      writeSync(fixturifyProject)
+      writeSync(fixturifyProject);
 
-      let linkPath = path.join(fixturifyProject.root, '/whatever/node_modules/ember-cli-babel');
-      let addonPath = path.resolve(__dirname, '../');
+      let linkPath = path.join(
+        fixturifyProject.root,
+        "/whatever/node_modules/ember-cli-babel"
+      );
+      let addonPath = path.resolve(__dirname, "../");
       rimraf.sync(linkPath);
-      fs.symlinkSync(addonPath, linkPath, 'junction');
+      fs.symlinkSync(addonPath, linkPath, "junction");
       unlink = () => {
         fs.unlinkSync(linkPath);
       };
 
       let cli = new MockCLI();
-      let root = path.join(fixturifyProject.root, 'whatever');
+      let root = path.join(fixturifyProject.root, "whatever");
       project = new EmberProject(root, pkg, cli.ui, cli);
       project.initializeAddons();
 
-      self.addon = project.addons.find(a => { return a.name === 'ember-cli-babel'; });
+      self.addon = project.addons.find((a) => {
+        return a.name === "ember-cli-babel";
+      });
       self.addon.parent.options = {
         "ember-cli-babel": { useBabelConfig: true },
       };
@@ -2284,81 +2574,90 @@ describe('babel config file', function() {
     });
   });
 
-  afterEach(co.wrap(function*() {
-    unlink();
+  afterEach(
+    co.wrap(function* () {
+      unlink();
 
-    if (input) {
-      yield input.dispose();
-    }
+      if (input) {
+        yield input.dispose();
+      }
 
-    if (output) {
-      yield output.dispose();
-    }
+      if (output) {
+        yield output.dispose();
+      }
 
-    // shut down workers after the tests are run so that mocha doesn't hang
-    yield terminateWorkerPool();
-  }));
+      // shut down workers after the tests are run so that mocha doesn't hang
+      yield terminateWorkerPool();
+    })
+  );
 
-  it("should transpile to amd modules based on babel config", co.wrap(function* () {
-    yield setupForVersion(`[
+  it(
+    "should transpile to amd modules based on babel config",
+    co.wrap(function* () {
+      yield setupForVersion(`[
       require.resolve("@babel/plugin-transform-modules-amd"),
       { noInterop: true },
     ]`);
-    input.write({
-      "foo.js": `export default {};`,
-    });
+      input.write({
+        "foo.js": `export default {};`,
+      });
 
-    subject = this.addon.transpileTree(input.path());
-    output = createBuilder(subject);
+      subject = this.addon.transpileTree(input.path());
+      output = createBuilder(subject);
 
-    yield output.build();
+      yield output.build();
 
-    expect(output.read()).to.deep.equal({
-      "foo.js": `define(\"foo\", [\"exports\"], function (_exports) {\n  \"use strict\";\n\n  Object.defineProperty(_exports, \"__esModule\", {\n    value: true\n  });\n  _exports.default = void 0;\n  var _default = {};\n  _exports.default = _default;\n});`,
-    });
-  }));
+      expect(output.read()).to.deep.equal({
+        "foo.js": `define(\"foo\", [\"exports\"], function (_exports) {\n  \"use strict\";\n\n  Object.defineProperty(_exports, \"__esModule\", {\n    value: true\n  });\n  _exports.default = void 0;\n  var _default = {};\n  _exports.default = _default;\n});`,
+      });
+    })
+  );
 
-  it("should not transpile to amd modules based on babel config", co.wrap(function* () {
-    yield setupForVersion('');
-    input.write({
-      "foo.js": `export default {};`,
-    });
+  it(
+    "should not transpile to amd modules based on babel config",
+    co.wrap(function* () {
+      yield setupForVersion("");
+      input.write({
+        "foo.js": `export default {};`,
+      });
 
-    subject = this.addon.transpileTree(input.path());
-    output = createBuilder(subject);
+      subject = this.addon.transpileTree(input.path());
+      output = createBuilder(subject);
 
-    yield output.build();
+      yield output.build();
 
-    expect(
-      output.read()
-    ).to.deep.equal({
-      "foo.js": "export default {};"
-    });
-  }));
+      expect(output.read()).to.deep.equal({
+        "foo.js": "export default {};",
+      });
+    })
+  );
 
-  it("should not use babel config (even if present) if the 'useBabelConfig' option is set to false", co.wrap(function* () {
-    yield setupForVersion(`[
+  it(
+    "should not use babel config (even if present) if the 'useBabelConfig' option is set to false",
+    co.wrap(function* () {
+      yield setupForVersion(`[
       "@babel/plugin-transform-modules-amd",
       { noInterop: true },
     ]`);
 
-    this.addon.parent.options = {
-      "ember-cli-babel": { useBabelConfig: false },
-    };
-    input.write({
-      "foo.js": `export default {};`,
-    });
+      this.addon.parent.options = {
+        "ember-cli-babel": { useBabelConfig: false },
+      };
+      input.write({
+        "foo.js": `export default {};`,
+      });
 
-    subject = this.addon.transpileTree(input.path());
-    output = createBuilder(subject);
+      subject = this.addon.transpileTree(input.path());
+      output = createBuilder(subject);
 
-    yield output.build();
+      yield output.build();
 
-    expect(output.read()).to.deep.equal({
-      "foo.js":
-        'define("foo", ["exports"], function (_exports) {\n  "use strict";\n\n  Object.defineProperty(_exports, "__esModule", {\n    value: true\n  });\n  _exports.default = void 0;\n  var _default = {};\n  _exports.default = _default;\n});',
-    });
-  }));
+      expect(output.read()).to.deep.equal({
+        "foo.js":
+          'define("foo", ["exports"], function (_exports) {\n  "use strict";\n\n  Object.defineProperty(_exports, "__esModule", {\n    value: true\n  });\n  _exports.default = void 0;\n  var _default = {};\n  _exports.default = _default;\n});',
+      });
+    })
+  );
 });
 
 function leftPad(str, num) {
@@ -2368,5 +2667,5 @@ function leftPad(str, num) {
   return str;
 }
 function assembleLines(lines, indent = 2) {
-  return lines.map(l => leftPad(l, indent)).join('\n');
+  return lines.map((l) => leftPad(l, indent)).join("\n");
 }

--- a/node-tests/get-babel-options-test.js
+++ b/node-tests/get-babel-options-test.js
@@ -69,8 +69,14 @@ describe("get-babel-options", function () {
   describe("_addDecoratorPlugins", function () {
     it("should include babel transforms by default", function () {
       expect(
-        _addDecoratorPlugins([], {}, {}, this.addon.parent, this.addon.project)
-          .length
+        _addDecoratorPlugins({
+          plugins: [],
+          options: {},
+          config: {},
+          parent: this.addon.parent,
+          project: this.addon.project,
+          isClassPropertiesRequired: true,
+        }).length
       ).to.equal(2, "plugins added correctly");
     });
 
@@ -84,13 +90,14 @@ describe("get-babel-options", function () {
       };
 
       expect(
-        _addDecoratorPlugins(
-          [["@babel/plugin-proposal-decorators"]],
-          {},
-          {},
-          this.addon.parent,
-          this.addon.project
-        ).length
+        _addDecoratorPlugins({
+          plugins: [["@babel/plugin-proposal-decorators"]],
+          options: {},
+          config: {},
+          parent: this.addon.parent,
+          project: this.addon.project,
+          isClassPropertiesRequired: true,
+        }).length
       ).to.equal(2, "plugins were not added");
     });
 
@@ -104,37 +111,40 @@ describe("get-babel-options", function () {
       };
 
       expect(
-        _addDecoratorPlugins(
-          [["@babel/plugin-proposal-class-properties"]],
-          {},
-          {},
-          this.addon.parent,
-          this.addon.project
-        ).length
+        _addDecoratorPlugins({
+          plugins: [["@babel/plugin-proposal-class-properties"]],
+          options: {},
+          config: {},
+          parent: this.addon.parent,
+          project: this.addon.project,
+          isClassPropertiesRequired: true,
+        }).length
       ).to.equal(2, "plugins were not added");
     });
 
     it("should use babel options loose mode for class properties", function () {
-      let strictPlugins = _addDecoratorPlugins(
-        [],
-        {},
-        {},
-        this.addon.parent,
-        this.addon.project
-      );
+      let strictPlugins = _addDecoratorPlugins({
+        plugins: [],
+        options: {},
+        config: {},
+        parent: this.addon.parent,
+        project: this.addon.project,
+        isClassPropertiesRequired: true,
+      });
 
       expect(strictPlugins[1][1].loose).to.equal(
         false,
         "loose is false if no option is provided"
       );
 
-      let loosePlugins = _addDecoratorPlugins(
-        [],
-        { loose: true },
-        {},
-        this.addon.parent,
-        this.addon.project
-      );
+      let loosePlugins = _addDecoratorPlugins({
+        plugins: [],
+        options: { loose: true },
+        config: {},
+        parent: this.addon.parent,
+        project: this.addon.project,
+        isClassPropertiesRequired: true,
+      });
 
       expect(loosePlugins[1][1].loose).to.equal(
         true,
@@ -146,13 +156,14 @@ describe("get-babel-options", function () {
       const config = {
         "ember-cli-babel": { enableTypeScriptTransform: true },
       };
-      let plugins = _addDecoratorPlugins(
-        ["@babel/plugin-transform-typescript"],
-        {},
+      let plugins = _addDecoratorPlugins({
+        plugins: ["@babel/plugin-transform-typescript"],
+        options: {},
         config,
-        this.addon.parent,
-        this.addon.project
-      );
+        parent: this.addon.parent,
+        project: this.addon.project,
+        isClassPropertiesRequired: true,
+      });
       expect(plugins[0]).to.equal(
         "@babel/plugin-transform-typescript",
         "typescript still first"
@@ -164,18 +175,35 @@ describe("get-babel-options", function () {
       const config = {
         "ember-cli-babel": { enableTypeScriptTransform: false },
       };
-      let plugins = _addDecoratorPlugins(
-        ["@babel/plugin-transform-typescript"],
-        {},
+      let plugins = _addDecoratorPlugins({
+        plugins: ["@babel/plugin-transform-typescript"],
+        options: {},
         config,
-        this.addon.parent,
-        this.addon.project
-      );
+        parent: this.addon.parent,
+        project: this.addon.project,
+        isClassPropertiesRequired: true,
+      });
 
       expect(plugins.length).to.equal(3, "class fields and decorators added");
       expect(plugins[2]).to.equal(
         "@babel/plugin-transform-typescript",
         "typescript is now last"
+      );
+    });
+
+    it("should not include class fields if they are not required", function () {
+      let plugins = _addDecoratorPlugins({
+        plugins: [],
+        options: {},
+        config: {},
+        parent: this.addon.parent,
+        project: this.addon.project,
+        isClassPropertiesRequired: false,
+      });
+      expect(plugins.length).to.equal(1, "only one plugin");
+      expect(plugins[0][0]).to.include(
+        require.resolve("@babel/plugin-proposal-decorators"),
+        "and the plugin is decorator"
       );
     });
   });

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/plugin-transform-runtime": "^7.13.9",
     "@babel/plugin-transform-typescript": "^7.13.0",
     "@babel/polyfill": "^7.11.5",
-    "@babel/preset-env": "^7.12.0",
+    "@babel/preset-env": "^7.16.4",
     "@babel/runtime": "7.12.18",
     "amd-name-resolver": "^1.3.1",
     "babel-plugin-debug-macros": "^0.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,13 @@
   dependencies:
     "@babel/highlight" "^7.12.13"
 
+"@babel/code-frame@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
+  integrity sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
+  dependencies:
+    "@babel/highlight" "^7.16.0"
+
 "@babel/compat-data@^7.12.0":
   version "7.12.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.0.tgz#443aea07a5aeba7942cb067de6b8272f2ab36b9e"
@@ -25,6 +32,11 @@
   version "7.13.8"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.8.tgz#5b783b9808f15cef71547f1b691f34f8ff6003a6"
   integrity sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==
+
+"@babel/compat-data@^7.13.11", "@babel/compat-data@^7.16.0", "@babel/compat-data@^7.16.4":
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.4.tgz#081d6bbc336ec5c2435c6346b2ae1fb98b5ac68e"
+  integrity sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==
 
 "@babel/core@^7.12.0", "@babel/core@^7.3.4", "@babel/core@^7.7.0":
   version "7.12.0"
@@ -57,12 +69,28 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.16.0.tgz#d40f3d1d5075e62d3500bccb67f3daa8a95265b2"
+  integrity sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==
+  dependencies:
+    "@babel/types" "^7.16.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/helper-annotate-as-pure@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz#5bf0d495a3f757ac3bda48b5bf3b3ba309c72ba3"
   integrity sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==
   dependencies:
     "@babel/types" "^7.10.4"
+
+"@babel/helper-annotate-as-pure@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz#9a1f0ebcda53d9a2d00108c4ceace6a5d5f1f08d"
+  integrity sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==
+  dependencies:
+    "@babel/types" "^7.16.0"
 
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.10.4":
   version "7.10.4"
@@ -71,6 +99,14 @@
   dependencies:
     "@babel/helper-explode-assignable-expression" "^7.10.4"
     "@babel/types" "^7.10.4"
+
+"@babel/helper-builder-binary-assignment-operator-visitor@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.0.tgz#f1a686b92da794020c26582eb852e9accd0d7882"
+  integrity sha512-9KuleLT0e77wFUku6TUkqZzCEymBdtuQQ27MhEKzf9UOOJu3cYj98kyaDAzxpC7lV6DGiZFuC8XqDsq8/Kl6aQ==
+  dependencies:
+    "@babel/helper-explode-assignable-expression" "^7.16.0"
+    "@babel/types" "^7.16.0"
 
 "@babel/helper-compilation-targets@^7.12.0":
   version "7.12.0"
@@ -92,6 +128,16 @@
     browserslist "^4.14.5"
     semver "^6.3.0"
 
+"@babel/helper-compilation-targets@^7.16.0", "@babel/helper-compilation-targets@^7.16.3":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz#5b480cd13f68363df6ec4dc8ac8e2da11363cbf0"
+  integrity sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==
+  dependencies:
+    "@babel/compat-data" "^7.16.0"
+    "@babel/helper-validator-option" "^7.14.5"
+    browserslist "^4.17.5"
+    semver "^6.3.0"
+
 "@babel/helper-create-class-features-plugin@^7.10.4", "@babel/helper-create-class-features-plugin@^7.10.5", "@babel/helper-create-class-features-plugin@^7.13.0":
   version "7.13.8"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.8.tgz#0367bd0a7505156ce018ca464f7ac91ba58c1a04"
@@ -103,6 +149,18 @@
     "@babel/helper-replace-supers" "^7.13.0"
     "@babel/helper-split-export-declaration" "^7.12.13"
 
+"@babel/helper-create-class-features-plugin@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.0.tgz#090d4d166b342a03a9fec37ef4fd5aeb9c7c6a4b"
+  integrity sha512-XLwWvqEaq19zFlF5PTgOod4bUA+XbkR4WLQBct1bkzmxJGB0ZEJaoKF4c8cgH9oBtCDuYJ8BP5NB9uFiEgO5QA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.0"
+    "@babel/helper-function-name" "^7.16.0"
+    "@babel/helper-member-expression-to-functions" "^7.16.0"
+    "@babel/helper-optimise-call-expression" "^7.16.0"
+    "@babel/helper-replace-supers" "^7.16.0"
+    "@babel/helper-split-export-declaration" "^7.16.0"
+
 "@babel/helper-create-regexp-features-plugin@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz#fdd60d88524659a0b6959c0579925e425714f3b8"
@@ -111,6 +169,14 @@
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/helper-regex" "^7.10.4"
     regexpu-core "^4.7.0"
+
+"@babel/helper-create-regexp-features-plugin@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.16.0.tgz#06b2348ce37fccc4f5e18dcd8d75053f2a7c44ff"
+  integrity sha512-3DyG0zAFAZKcOp7aVr33ddwkxJ0Z0Jr5V99y3I690eYLpukJsJvAbzTy1ewoCqsML8SbIrjH14Jc/nSQ4TvNPA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.0"
+    regexpu-core "^4.7.1"
 
 "@babel/helper-define-map@^7.10.4":
   version "7.10.5"
@@ -135,6 +201,20 @@
     resolve "^1.14.2"
     semver "^6.1.2"
 
+"@babel/helper-define-polyfill-provider@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz#c5b10cf4b324ff840140bb07e05b8564af2ae971"
+  integrity sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.13.0"
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/traverse" "^7.13.0"
+    debug "^4.1.1"
+    lodash.debounce "^4.0.8"
+    resolve "^1.14.2"
+    semver "^6.1.2"
+
 "@babel/helper-explode-assignable-expression@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz#40a1cd917bff1288f699a94a75b37a1a2dbd8c7c"
@@ -142,6 +222,13 @@
   dependencies:
     "@babel/traverse" "^7.10.4"
     "@babel/types" "^7.10.4"
+
+"@babel/helper-explode-assignable-expression@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.0.tgz#753017337a15f46f9c09f674cff10cee9b9d7778"
+  integrity sha512-Hk2SLxC9ZbcOhLpg/yMznzJ11W++lg5GMbxt1ev6TXUiJB0N42KPC+7w8a+eWGuqDnUYuwStJoZHM7RgmIOaGQ==
+  dependencies:
+    "@babel/types" "^7.16.0"
 
 "@babel/helper-function-name@^7.10.4", "@babel/helper-function-name@^7.12.13":
   version "7.12.13"
@@ -152,12 +239,28 @@
     "@babel/template" "^7.12.13"
     "@babel/types" "^7.12.13"
 
+"@babel/helper-function-name@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz#b7dd0797d00bbfee4f07e9c4ea5b0e30c8bb1481"
+  integrity sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.16.0"
+    "@babel/template" "^7.16.0"
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-get-function-arity@^7.10.4", "@babel/helper-get-function-arity@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz#bc63451d403a3b3082b97e1d8b3fe5bd4091e583"
   integrity sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
   dependencies:
     "@babel/types" "^7.12.13"
+
+"@babel/helper-get-function-arity@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz#0088c7486b29a9cb5d948b1a1de46db66e089cfa"
+  integrity sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==
+  dependencies:
+    "@babel/types" "^7.16.0"
 
 "@babel/helper-hoist-variables@^7.10.4":
   version "7.10.4"
@@ -166,6 +269,13 @@
   dependencies:
     "@babel/types" "^7.10.4"
 
+"@babel/helper-hoist-variables@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz#4c9023c2f1def7e28ff46fc1dbcd36a39beaa81a"
+  integrity sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-member-expression-to-functions@^7.12.0", "@babel/helper-member-expression-to-functions@^7.13.0":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz#6aa4bb678e0f8c22f58cdb79451d30494461b091"
@@ -173,12 +283,26 @@
   dependencies:
     "@babel/types" "^7.13.0"
 
+"@babel/helper-member-expression-to-functions@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz#29287040efd197c77636ef75188e81da8bccd5a4"
+  integrity sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz#ec67e4404f41750463e455cc3203f6a32e93fcb0"
   integrity sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==
   dependencies:
     "@babel/types" "^7.12.13"
+
+"@babel/helper-module-imports@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz#90538e60b672ecf1b448f5f4f5433d37e79a3ec3"
+  integrity sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==
+  dependencies:
+    "@babel/types" "^7.16.0"
 
 "@babel/helper-module-transforms@^7.10.4", "@babel/helper-module-transforms@^7.12.0":
   version "7.12.0"
@@ -210,12 +334,33 @@
     "@babel/types" "^7.13.0"
     lodash "^4.17.19"
 
+"@babel/helper-module-transforms@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz#1c82a8dd4cb34577502ebd2909699b194c3e9bb5"
+  integrity sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.16.0"
+    "@babel/helper-replace-supers" "^7.16.0"
+    "@babel/helper-simple-access" "^7.16.0"
+    "@babel/helper-split-export-declaration" "^7.16.0"
+    "@babel/helper-validator-identifier" "^7.15.7"
+    "@babel/template" "^7.16.0"
+    "@babel/traverse" "^7.16.0"
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-optimise-call-expression@^7.10.4", "@babel/helper-optimise-call-expression@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz#5c02d171b4c8615b1e7163f888c1c81c30a2aaea"
   integrity sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
   dependencies:
     "@babel/types" "^7.12.13"
+
+"@babel/helper-optimise-call-expression@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz#cecdb145d70c54096b1564f8e9f10cd7d193b338"
+  integrity sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==
+  dependencies:
+    "@babel/types" "^7.16.0"
 
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.10.4"
@@ -226,6 +371,11 @@
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz#806526ce125aed03373bc416a828321e3a6a33af"
   integrity sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
+
+"@babel/helper-plugin-utils@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
+  integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
 
 "@babel/helper-regex@^7.10.4":
   version "7.10.5"
@@ -244,6 +394,15 @@
     "@babel/template" "^7.10.4"
     "@babel/traverse" "^7.10.4"
     "@babel/types" "^7.10.4"
+
+"@babel/helper-remap-async-to-generator@^7.16.0", "@babel/helper-remap-async-to-generator@^7.16.4":
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.4.tgz#5d7902f61349ff6b963e07f06a389ce139fbfe6e"
+  integrity sha512-vGERmmhR+s7eH5Y/cp8PCVzj4XEjerq8jooMfxFdA5xVtAk9Sh4AQsrWgiErUEBjtGrBtOFKDUcWQFW4/dFwMA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.0"
+    "@babel/helper-wrap-function" "^7.16.0"
+    "@babel/types" "^7.16.0"
 
 "@babel/helper-replace-supers@^7.10.4":
   version "7.12.0"
@@ -265,12 +424,29 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
+"@babel/helper-replace-supers@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz#73055e8d3cf9bcba8ddb55cad93fedc860f68f17"
+  integrity sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.16.0"
+    "@babel/helper-optimise-call-expression" "^7.16.0"
+    "@babel/traverse" "^7.16.0"
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-simple-access@^7.10.4", "@babel/helper-simple-access@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz#8478bcc5cacf6aa1672b251c1d2dde5ccd61a6c4"
   integrity sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==
   dependencies:
     "@babel/types" "^7.12.13"
+
+"@babel/helper-simple-access@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz#21d6a27620e383e37534cf6c10bba019a6f90517"
+  integrity sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==
+  dependencies:
+    "@babel/types" "^7.16.0"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.11.0":
   version "7.11.0"
@@ -279,6 +455,13 @@
   dependencies:
     "@babel/types" "^7.11.0"
 
+"@babel/helper-skip-transparent-expression-wrappers@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz#0ee3388070147c3ae051e487eca3ebb0e2e8bb09"
+  integrity sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-split-export-declaration@^7.10.4", "@babel/helper-split-export-declaration@^7.11.0", "@babel/helper-split-export-declaration@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz#e9430be00baf3e88b0e13e6f9d4eaf2136372b05"
@@ -286,10 +469,22 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
+"@babel/helper-split-export-declaration@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz#29672f43663e936df370aaeb22beddb3baec7438"
+  integrity sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
   integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+
+"@babel/helper-validator-identifier@^7.15.7":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
+  integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
 "@babel/helper-validator-option@^7.12.0":
   version "7.12.0"
@@ -301,6 +496,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz#d1fbf012e1a79b7eebbfdc6d270baaf8d9eb9831"
   integrity sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==
 
+"@babel/helper-validator-option@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
+  integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
+
 "@babel/helper-wrap-function@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz#8a6f701eab0ff39f765b5a1cfef409990e624b87"
@@ -310,6 +510,16 @@
     "@babel/template" "^7.10.4"
     "@babel/traverse" "^7.10.4"
     "@babel/types" "^7.10.4"
+
+"@babel/helper-wrap-function@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.16.0.tgz#b3cf318afce774dfe75b86767cd6d68f3482e57c"
+  integrity sha512-VVMGzYY3vkWgCJML+qVLvGIam902mJW0FvT7Avj1zEe0Gn7D93aWdLblYARTxEw+6DhZmtzhBM2zv0ekE5zg1g==
+  dependencies:
+    "@babel/helper-function-name" "^7.16.0"
+    "@babel/template" "^7.16.0"
+    "@babel/traverse" "^7.16.0"
+    "@babel/types" "^7.16.0"
 
 "@babel/helpers@^7.10.4":
   version "7.10.4"
@@ -329,15 +539,45 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.0.tgz#6ceb32b2ca4b8f5f361fb7fd821e3fddf4a1725a"
+  integrity sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.15.7"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.12.0", "@babel/parser@^7.12.13", "@babel/parser@^7.13.0":
   version "7.13.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.9.tgz#ca34cb95e1c2dd126863a84465ae8ef66114be99"
   integrity sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==
 
+"@babel/parser@^7.16.0", "@babel/parser@^7.16.3":
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.4.tgz#d5f92f57cf2c74ffe9b37981c0e72fee7311372e"
+  integrity sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==
+
 "@babel/parser@^7.7.0":
   version "7.12.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.0.tgz#2ad388f3960045b22f9b7d4bf85e80b15a1c9e3a"
   integrity sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==
+
+"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.2":
+  version "7.16.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.2.tgz#2977fca9b212db153c195674e57cfab807733183"
+  integrity sha512-h37CvpLSf8gb2lIJ2CgC3t+EjFbi0t8qS7LCS1xcJIlEXE4czlofwaW7W1HA8zpgOCzI9C1nmoqNR1zWkk0pQg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.0.tgz#358972eaab006f5eb0826183b0c93cbcaf13e1e2"
+  integrity sha512-4tcFwwicpWTrpl9qjf7UsoosaArgImF85AxqCRZlgc3IQDvkUHjJpruXAL58Wmj+T6fypWTC/BakfEkwIL/pwA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.16.0"
+    "@babel/plugin-proposal-optional-chaining" "^7.16.0"
 
 "@babel/plugin-proposal-async-generator-functions@^7.10.4":
   version "7.10.5"
@@ -347,6 +587,15 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-remap-async-to-generator" "^7.10.4"
     "@babel/plugin-syntax-async-generators" "^7.8.0"
+
+"@babel/plugin-proposal-async-generator-functions@^7.16.4":
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.4.tgz#e606eb6015fec6fa5978c940f315eae4e300b081"
+  integrity sha512-/CUekqaAaZCQHleSK/9HajvcD/zdnJiKRiuUFq8ITE+0HsPzquf53cpFiqAwl/UfmJbR6n5uGPQSPdrmKOvHHg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-remap-async-to-generator" "^7.16.4"
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
 
 "@babel/plugin-proposal-class-properties@^7.1.0", "@babel/plugin-proposal-class-properties@^7.7.0":
   version "7.10.4"
@@ -363,6 +612,23 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.13.0"
     "@babel/helper-plugin-utils" "^7.13.0"
+
+"@babel/plugin-proposal-class-properties@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.0.tgz#c029618267ddebc7280fa286e0f8ca2a278a2d1a"
+  integrity sha512-mCF3HcuZSY9Fcx56Lbn+CGdT44ioBMMvjNVldpKtj8tpniETdLjnxdHI1+sDWXIM1nNt+EanJOZ3IG9lzVjs7A==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-proposal-class-static-block@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.16.0.tgz#5296942c564d8144c83eea347d0aa8a0b89170e7"
+  integrity sha512-mAy3sdcY9sKAkf3lQbDiv3olOfiLqI51c9DR9b19uMoR2Z6r5pmGl7dfNFqEvqOyqbf1ta4lknK4gc5PJn3mfA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-class-static-block" "^7.14.5"
 
 "@babel/plugin-proposal-decorators@^7.13.5":
   version "7.13.5"
@@ -390,12 +656,28 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-dynamic-import" "^7.8.0"
 
+"@babel/plugin-proposal-dynamic-import@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.0.tgz#783eca61d50526202f9b296095453977e88659f1"
+  integrity sha512-QGSA6ExWk95jFQgwz5GQ2Dr95cf7eI7TKutIXXTb7B1gCLTCz5hTjFTQGfLFBBiC5WSNi7udNwWsqbbMh1c4yQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+
 "@babel/plugin-proposal-export-namespace-from@^7.12.0":
   version "7.12.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.0.tgz#08b0f8100bbae1199a5f5294f38a1b0b8d8402fc"
   integrity sha512-ao43U2ptSe+mIZAQo2nBV5Wx2Ie3i2XbLt8jCXZpv+bvLY1Twv0lak4YZ1Ps5OwbeLMAl3iOVScgGMOImBae1g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
+
+"@babel/plugin-proposal-export-namespace-from@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.0.tgz#9c01dee40b9d6b847b656aaf4a3976a71740f222"
+  integrity sha512-CjI4nxM/D+5wCnhD11MHB1AwRSAYeDT+h8gCdcVJZ/OK7+wRzFsf7PFPWVpVpNRkHMmMkQWAHpTq+15IXQ1diA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
 
 "@babel/plugin-proposal-json-strings@^7.10.4":
@@ -406,12 +688,28 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-json-strings" "^7.8.0"
 
+"@babel/plugin-proposal-json-strings@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.0.tgz#cae35a95ed1d2a7fa29c4dc41540b84a72e9ab25"
+  integrity sha512-kouIPuiv8mSi5JkEhzApg5Gn6hFyKPnlkO0a9YSzqRurH8wYzSlf6RJdzluAsbqecdW5pBvDJDfyDIUR/vLxvg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
+
 "@babel/plugin-proposal-logical-assignment-operators@^7.12.0":
   version "7.12.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.0.tgz#830d8ff4984d800b2824e8eac0005ecb7430328e"
   integrity sha512-dssjXHzdMQal4q6GCSwDTVPEbyBLdd9+7aSlzAkQbrGEKq5xG8pvhQ7u2ktUrCLRmzQphZnSzILBL5ta4xSRlA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+
+"@babel/plugin-proposal-logical-assignment-operators@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.0.tgz#a711b8ceb3ffddd3ef88d3a49e86dbd3cc7db3fd"
+  integrity sha512-pbW0fE30sVTYXXm9lpVQQ/Vc+iTeQKiXlaNRZPPN2A2VdlWyAtsUrsQ3xydSlDW00TFMK7a8m3cDTkBF5WnV3Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
 
 "@babel/plugin-proposal-nullish-coalescing-operator@^7.12.0":
@@ -422,12 +720,28 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
 
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.0.tgz#44e1cce08fe2427482cf446a91bb451528ed0596"
+  integrity sha512-3bnHA8CAFm7cG93v8loghDYyQ8r97Qydf63BeYiGgYbjKKB/XP53W15wfRC7dvKfoiJ34f6Rbyyx2btExc8XsQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+
 "@babel/plugin-proposal-numeric-separator@^7.12.0":
   version "7.12.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.0.tgz#76de244152abaf2e72800ab0aebc9771f6de3e9a"
   integrity sha512-iON65YmIy/IpEgteYJ4HfO2q30SLdIxiyjNNlsSjSl0tUxLhSH9PljE5r6sczwdW64ZZzznYNcezdcROB+rDDw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+
+"@babel/plugin-proposal-numeric-separator@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.0.tgz#5d418e4fbbf8b9b7d03125d3a52730433a373734"
+  integrity sha512-FAhE2I6mjispy+vwwd6xWPyEx3NYFS13pikDBWUAFGZvq6POGs5eNchw8+1CYoEgBl9n11I3NkzD7ghn25PQ9Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
 "@babel/plugin-proposal-object-rest-spread@^7.11.0":
@@ -439,6 +753,17 @@
     "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
     "@babel/plugin-transform-parameters" "^7.10.4"
 
+"@babel/plugin-proposal-object-rest-spread@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.16.0.tgz#5fb32f6d924d6e6712810362a60e12a2609872e6"
+  integrity sha512-LU/+jp89efe5HuWJLmMmFG0+xbz+I2rSI7iLc1AlaeSMDMOGzWlc5yJrMN1d04osXN4sSfpo4O+azkBNBes0jg==
+  dependencies:
+    "@babel/compat-data" "^7.16.0"
+    "@babel/helper-compilation-targets" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-transform-parameters" "^7.16.0"
+
 "@babel/plugin-proposal-optional-catch-binding@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz#31c938309d24a78a49d68fdabffaa863758554dd"
@@ -446,6 +771,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
+
+"@babel/plugin-proposal-optional-catch-binding@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.0.tgz#5910085811ab4c28b00d6ebffa4ab0274d1e5f16"
+  integrity sha512-kicDo0A/5J0nrsCPbn89mTG3Bm4XgYi0CZtvex9Oyw7gGZE3HXGD0zpQNH+mo+tEfbo8wbmMvJftOwpmPy7aVw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
 
 "@babel/plugin-proposal-optional-chaining@^7.12.0":
   version "7.12.0"
@@ -456,6 +789,15 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.11.0"
     "@babel/plugin-syntax-optional-chaining" "^7.8.0"
 
+"@babel/plugin-proposal-optional-chaining@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.0.tgz#56dbc3970825683608e9efb55ea82c2a2d6c8dc0"
+  integrity sha512-Y4rFpkZODfHrVo70Uaj6cC1JJOt3Pp0MdWSwIKtb8z1/lsjl9AmnB7ErRFV+QNGIfcY1Eruc2UMx5KaRnXjMyg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.16.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+
 "@babel/plugin-proposal-private-methods@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz#b160d972b8fdba5c7d111a145fc8c421fc2a6909"
@@ -463,6 +805,24 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-proposal-private-methods@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.0.tgz#b4dafb9c717e4301c5776b30d080d6383c89aff6"
+  integrity sha512-IvHmcTHDFztQGnn6aWq4t12QaBXTKr1whF/dgp9kz84X6GUcwq9utj7z2wFCUfeOup/QKnOlt2k0zxkGFx9ubg==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-proposal-private-property-in-object@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.0.tgz#69e935b2c5c79d2488112d886f0c4e2790fee76f"
+  integrity sha512-3jQUr/HBbMVZmi72LpjQwlZ55i1queL8KcDTQEkAHihttJnAPrcvG9ZNXIfsd2ugpizZo595egYV6xy+pv4Ofw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.0"
+    "@babel/helper-create-class-features-plugin" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
 
 "@babel/plugin-proposal-unicode-property-regex@^7.10.4", "@babel/plugin-proposal-unicode-property-regex@^7.4.4":
   version "7.10.4"
@@ -472,7 +832,15 @@
     "@babel/helper-create-regexp-features-plugin" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-async-generators@^7.8.0":
+"@babel/plugin-proposal-unicode-property-regex@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.0.tgz#890482dfc5ea378e42e19a71e709728cabf18612"
+  integrity sha512-ti7IdM54NXv29cA4+bNNKEMS4jLMCbJgl+Drv+FgYy0erJLAxNAIXcNjNjrRZEcWq0xJHsNVwQezskMFpF8N9g==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-async-generators@^7.8.0", "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
   integrity sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
@@ -486,6 +854,20 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-syntax-class-properties@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz#b5c987274c4a3a82b89714796931a6b53544ae10"
+  integrity sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
+
+"@babel/plugin-syntax-class-static-block@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz#195df89b146b4b78b3bf897fd7a257c84659d406"
+  integrity sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-syntax-decorators@^7.10.4", "@babel/plugin-syntax-decorators@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.13.tgz#fac829bf3c7ef4a1bc916257b403e58c6bdaf648"
@@ -493,7 +875,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-syntax-dynamic-import@^7.8.0":
+"@babel/plugin-syntax-dynamic-import@^7.8.0", "@babel/plugin-syntax-dynamic-import@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
   integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
@@ -507,7 +889,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-json-strings@^7.8.0":
+"@babel/plugin-syntax-json-strings@^7.8.0", "@babel/plugin-syntax-json-strings@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz#01ca21b668cd8218c9e640cb6dd88c5412b2c96a"
   integrity sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
@@ -521,7 +903,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0":
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0", "@babel/plugin-syntax-nullish-coalescing-operator@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
   integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
@@ -535,26 +917,33 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-object-rest-spread@^7.8.0":
+"@babel/plugin-syntax-object-rest-spread@^7.8.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
   integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-optional-catch-binding@^7.8.0":
+"@babel/plugin-syntax-optional-catch-binding@^7.8.0", "@babel/plugin-syntax-optional-catch-binding@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz#6111a265bcfb020eb9efd0fdfd7d26402b9ed6c1"
   integrity sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-optional-chaining@^7.8.0":
+"@babel/plugin-syntax-optional-chaining@^7.8.0", "@babel/plugin-syntax-optional-chaining@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz#4f69c2ab95167e0180cd5336613f8c5788f7d48a"
   integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-private-property-in-object@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz#0dc6671ec0ea22b6e94a1114f857970cd39de1ad"
+  integrity sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-syntax-top-level-await@^7.10.4":
   version "7.10.4"
@@ -562,6 +951,13 @@
   integrity sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-top-level-await@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz#c1cfdadc35a646240001f06138247b741c34d94c"
+  integrity sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-syntax-typescript@^7.12.13":
   version "7.12.13"
@@ -584,6 +980,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-arrow-functions@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.0.tgz#951706f8b449c834ed07bd474c0924c944b95a8e"
+  integrity sha512-vIFb5250Rbh7roWARvCLvIJ/PtAU5Lhv7BtZ1u24COwpI9Ypjsh+bZcKk6rlIyalK+r0jOc1XQ8I4ovNxNrWrA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-async-to-generator@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz#41a5017e49eb6f3cda9392a51eef29405b245a37"
@@ -593,6 +996,15 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-remap-async-to-generator" "^7.10.4"
 
+"@babel/plugin-transform-async-to-generator@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.0.tgz#df12637f9630ddfa0ef9d7a11bc414d629d38604"
+  integrity sha512-PbIr7G9kR8tdH6g8Wouir5uVjklETk91GMVSUq+VaOgiinbCkBP6Q7NN/suM/QutZkMJMvcyAriogcYAdhg8Gw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-remap-async-to-generator" "^7.16.0"
+
 "@babel/plugin-transform-block-scoped-functions@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz#1afa595744f75e43a91af73b0d998ecfe4ebc2e8"
@@ -600,12 +1012,26 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-block-scoped-functions@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.0.tgz#c618763233ad02847805abcac4c345ce9de7145d"
+  integrity sha512-V14As3haUOP4ZWrLJ3VVx5rCnrYhMSHN/jX7z6FAt5hjRkLsb0snPCmJwSOML5oxkKO4FNoNv7V5hw/y2bjuvg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-block-scoping@^7.10.4":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.5.tgz#b81b8aafefbfe68f0f65f7ef397b9ece68a6037d"
   integrity sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-block-scoping@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.0.tgz#bcf433fb482fe8c3d3b4e8a66b1c4a8e77d37c16"
+  integrity sha512-27n3l67/R3UrXfizlvHGuTwsRIFyce3D/6a37GRxn28iyTPvNXaW4XvznexRh1zUNLPjbLL22Id0XQElV94ruw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-classes@^7.10.4":
   version "7.10.4"
@@ -621,6 +1047,19 @@
     "@babel/helper-split-export-declaration" "^7.10.4"
     globals "^11.1.0"
 
+"@babel/plugin-transform-classes@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.0.tgz#54cf5ff0b2242c6573d753cd4bfc7077a8b282f5"
+  integrity sha512-HUxMvy6GtAdd+GKBNYDWCIA776byUQH8zjnfjxwT1P1ARv/wFu8eBDpmXQcLS/IwRtrxIReGiplOwMeyO7nsDQ==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.0"
+    "@babel/helper-function-name" "^7.16.0"
+    "@babel/helper-optimise-call-expression" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-replace-supers" "^7.16.0"
+    "@babel/helper-split-export-declaration" "^7.16.0"
+    globals "^11.1.0"
+
 "@babel/plugin-transform-computed-properties@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz#9ded83a816e82ded28d52d4b4ecbdd810cdfc0eb"
@@ -628,12 +1067,26 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-computed-properties@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.0.tgz#e0c385507d21e1b0b076d66bed6d5231b85110b7"
+  integrity sha512-63l1dRXday6S8V3WFY5mXJwcRAnPYxvFfTlt67bwV1rTyVTM5zrp0DBBb13Kl7+ehkCVwIZPumPpFP/4u70+Tw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-destructuring@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz#70ddd2b3d1bea83d01509e9bb25ddb3a74fc85e5"
   integrity sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-destructuring@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.16.0.tgz#ad3d7e74584ad5ea4eadb1e6642146c590dee33c"
+  integrity sha512-Q7tBUwjxLTsHEoqktemHBMtb3NYwyJPTJdM+wDwb0g8PZ3kQUIzNvwD5lPaqW/p54TXBc/MXZu9Jr7tbUEUM8Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-dotall-regex@^7.10.4", "@babel/plugin-transform-dotall-regex@^7.4.4":
   version "7.10.4"
@@ -643,12 +1096,27 @@
     "@babel/helper-create-regexp-features-plugin" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-dotall-regex@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.0.tgz#50bab00c1084b6162d0a58a818031cf57798e06f"
+  integrity sha512-FXlDZfQeLILfJlC6I1qyEwcHK5UpRCFkaoVyA1nk9A1L1Yu583YO4un2KsLBsu3IJb4CUbctZks8tD9xPQubLw==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-duplicate-keys@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz#697e50c9fee14380fe843d1f306b295617431e47"
   integrity sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-duplicate-keys@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.0.tgz#8bc2e21813e3e89e5e5bf3b60aa5fc458575a176"
+  integrity sha512-LIe2kcHKAZOJDNxujvmp6z3mfN6V9lJxubU4fJIGoQCkKe3Ec2OcbdlYP+vW++4MpxwG0d1wSDOJtQW5kLnkZQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-exponentiation-operator@^7.10.4":
   version "7.10.4"
@@ -658,12 +1126,27 @@
     "@babel/helper-builder-binary-assignment-operator-visitor" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-exponentiation-operator@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.0.tgz#a180cd2881e3533cef9d3901e48dad0fbeff4be4"
+  integrity sha512-OwYEvzFI38hXklsrbNivzpO3fh87skzx8Pnqi4LoSYeav0xHlueSoCJrSgTPfnbyzopo5b3YVAJkFIcUpK2wsw==
+  dependencies:
+    "@babel/helper-builder-binary-assignment-operator-visitor" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-for-of@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz#c08892e8819d3a5db29031b115af511dbbfebae9"
   integrity sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-for-of@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.0.tgz#f7abaced155260e2461359bbc7c7248aca5e6bd2"
+  integrity sha512-5QKUw2kO+GVmKr2wMYSATCTTnHyscl6sxFRAY+rvN7h7WB0lcG0o4NoV6ZQU32OZGVsYUsfLGgPQpDFdkfjlJQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-function-name@^7.10.4":
   version "7.10.4"
@@ -673,6 +1156,14 @@
     "@babel/helper-function-name" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-function-name@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.0.tgz#02e3699c284c6262236599f751065c5d5f1f400e"
+  integrity sha512-lBzMle9jcOXtSOXUpc7tvvTpENu/NuekNJVova5lCCWCV9/U1ho2HH2y0p6mBg8fPm/syEAbfaaemYGOHCY3mg==
+  dependencies:
+    "@babel/helper-function-name" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-literals@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz#9f42ba0841100a135f22712d0e391c462f571f3c"
@@ -680,12 +1171,26 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-literals@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.0.tgz#79711e670ffceb31bd298229d50f3621f7980cac"
+  integrity sha512-gQDlsSF1iv9RU04clgXqRjrPyyoJMTclFt3K1cjLmTKikc0s/6vE3hlDeEVC71wLTRu72Fq7650kABrdTc2wMQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-member-expression-literals@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz#b1ec44fcf195afcb8db2c62cd8e551c881baf8b7"
   integrity sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-member-expression-literals@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.0.tgz#5251b4cce01eaf8314403d21aedb269d79f5e64b"
+  integrity sha512-WRpw5HL4Jhnxw8QARzRvwojp9MIE7Tdk3ez6vRyUk1MwgjJN0aNpRoXainLR5SgxmoXx/vsXGZ6OthP6t/RbUg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-modules-amd@^7.10.4", "@babel/plugin-transform-modules-amd@^7.5.0":
   version "7.10.5"
@@ -705,6 +1210,15 @@
     "@babel/helper-plugin-utils" "^7.13.0"
     babel-plugin-dynamic-import-node "^2.3.3"
 
+"@babel/plugin-transform-modules-amd@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.0.tgz#09abd41e18dcf4fd479c598c1cef7bd39eb1337e"
+  integrity sha512-rWFhWbCJ9Wdmzln1NmSCqn7P0RAD+ogXG/bd9Kg5c7PKWkJtkiXmYsMBeXjDlzHpVTJ4I/hnjs45zX4dEv81xw==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
 "@babel/plugin-transform-modules-commonjs@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz#66667c3eeda1ebf7896d41f1f16b17105a2fbca0"
@@ -713,6 +1227,16 @@
     "@babel/helper-module-transforms" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-simple-access" "^7.10.4"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
+"@babel/plugin-transform-modules-commonjs@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.0.tgz#add58e638c8ddc4875bd9a9ecb5c594613f6c922"
+  integrity sha512-Dzi+NWqyEotgzk/sb7kgQPJQf7AJkQBWsVp1N6JWc1lBVo0vkElUnGdr1PzUBmfsCCN5OOFya3RtpeHk15oLKQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-simple-access" "^7.16.0"
     babel-plugin-dynamic-import-node "^2.3.3"
 
 "@babel/plugin-transform-modules-systemjs@^7.12.0":
@@ -726,6 +1250,17 @@
     "@babel/helper-validator-identifier" "^7.10.4"
     babel-plugin-dynamic-import-node "^2.3.3"
 
+"@babel/plugin-transform-modules-systemjs@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.0.tgz#a92cf240afeb605f4ca16670453024425e421ea4"
+  integrity sha512-yuGBaHS3lF1m/5R+6fjIke64ii5luRUg97N2wr+z1sF0V+sNSXPxXDdEEL/iYLszsN5VKxVB1IPfEqhzVpiqvg==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.16.0"
+    "@babel/helper-module-transforms" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-validator-identifier" "^7.15.7"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
 "@babel/plugin-transform-modules-umd@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz#9a8481fe81b824654b3a0b65da3df89f3d21839e"
@@ -734,6 +1269,14 @@
     "@babel/helper-module-transforms" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-modules-umd@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.0.tgz#195f26c2ad6d6a391b70880effce18ce625e06a7"
+  integrity sha512-nx4f6no57himWiHhxDM5pjwhae5vLpTK2zCnDH8+wNLJy0TVER/LJRHl2bkt6w9Aad2sPD5iNNoUpY3X9sTGDg==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-named-capturing-groups-regex@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz#78b4d978810b6f3bcf03f9e318f2fc0ed41aecb6"
@@ -741,12 +1284,26 @@
   dependencies:
     "@babel/helper-create-regexp-features-plugin" "^7.10.4"
 
+"@babel/plugin-transform-named-capturing-groups-regex@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.0.tgz#d3db61cc5d5b97986559967cd5ea83e5c32096ca"
+  integrity sha512-LogN88uO+7EhxWc8WZuQ8vxdSyVGxhkh8WTC3tzlT8LccMuQdA81e9SGV6zY7kY2LjDhhDOFdQVxdGwPyBCnvg==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.16.0"
+
 "@babel/plugin-transform-new-target@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz#9097d753cb7b024cb7381a3b2e52e9513a9c6888"
   integrity sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-new-target@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.16.0.tgz#af823ab576f752215a49937779a41ca65825ab35"
+  integrity sha512-fhjrDEYv2DBsGN/P6rlqakwRwIp7rBGLPbrKxwh7oVt5NNkIhZVOY2GRV+ULLsQri1bDqwDWnU3vhlmx5B2aCw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-object-super@^7.10.4":
   version "7.10.4"
@@ -756,6 +1313,14 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-replace-supers" "^7.10.4"
 
+"@babel/plugin-transform-object-super@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.0.tgz#fb20d5806dc6491a06296ac14ea8e8d6fedda72b"
+  integrity sha512-fds+puedQHn4cPLshoHcR1DTMN0q1V9ou0mUjm8whx9pGcNvDrVVrgw+KJzzCaiTdaYhldtrUps8DWVMgrSEyg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-replace-supers" "^7.16.0"
+
 "@babel/plugin-transform-parameters@^7.10.4":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz#59d339d58d0b1950435f4043e74e2510005e2c4a"
@@ -764,6 +1329,13 @@
     "@babel/helper-get-function-arity" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-parameters@^7.16.0", "@babel/plugin-transform-parameters@^7.16.3":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.3.tgz#fa9e4c874ee5223f891ee6fa8d737f4766d31d15"
+  integrity sha512-3MaDpJrOXT1MZ/WCmkOFo7EtmVVC8H4EUZVrHvFOsmwkk4lOjQj8rzv8JKUZV4YoQKeoIgk07GO+acPU9IMu/w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-property-literals@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz#f6fe54b6590352298785b83edd815d214c42e3c0"
@@ -771,10 +1343,24 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-property-literals@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.0.tgz#a95c552189a96a00059f6776dc4e00e3690c78d1"
+  integrity sha512-XLldD4V8+pOqX2hwfWhgwXzGdnDOThxaNTgqagOcpBgIxbUvpgU2FMvo5E1RyHbk756WYgdbS0T8y0Cj9FKkWQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-regenerator@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz#2015e59d839074e76838de2159db421966fd8b63"
   integrity sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==
+  dependencies:
+    regenerator-transform "^0.14.2"
+
+"@babel/plugin-transform-regenerator@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.0.tgz#eaee422c84b0232d03aea7db99c97deeaf6125a4"
+  integrity sha512-JAvGxgKuwS2PihiSFaDrp94XOzzTUeDeOQlcKzVAyaPap7BnZXK/lvMDiubkPTdotPKOIZq9xWXWnggUMYiExg==
   dependencies:
     regenerator-transform "^0.14.2"
 
@@ -784,6 +1370,13 @@
   integrity sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-reserved-words@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.0.tgz#fff4b9dcb19e12619394bda172d14f2d04c0379c"
+  integrity sha512-Dgs8NNCehHSvXdhEhln8u/TtJxfVwGYCgP2OOr5Z3Ar+B+zXicEOKNTyc+eca2cuEOMtjW6m9P9ijOt8QdqWkg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-runtime@^7.13.9":
   version "7.13.9"
@@ -814,6 +1407,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-shorthand-properties@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.0.tgz#090372e3141f7cc324ed70b3daf5379df2fa384d"
+  integrity sha512-iVb1mTcD8fuhSv3k99+5tlXu5N0v8/DPm2mO3WACLG6al1CGZH7v09HJyUb1TtYl/Z+KrM6pHSIJdZxP5A+xow==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-spread@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz#fa84d300f5e4f57752fe41a6d1b3c554f13f17cc"
@@ -821,6 +1421,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.11.0"
+
+"@babel/plugin-transform-spread@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.0.tgz#d21ca099bbd53ab307a8621e019a7bd0f40cdcfb"
+  integrity sha512-Ao4MSYRaLAQczZVp9/7E7QHsCuK92yHRrmVNRe/SlEJjhzivq0BSn8mEraimL8wizHZ3fuaHxKH0iwzI13GyGg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.16.0"
 
 "@babel/plugin-transform-sticky-regex@^7.10.4":
   version "7.10.4"
@@ -830,6 +1438,13 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-regex" "^7.10.4"
 
+"@babel/plugin-transform-sticky-regex@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.0.tgz#c35ea31a02d86be485f6aa510184b677a91738fd"
+  integrity sha512-/ntT2NljR9foobKk4E/YyOSwcGUXtYWv5tinMK/3RkypyNBNdhHUaq6Orw5DWq9ZcNlS03BIlEALFeQgeVAo4Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-template-literals@^7.10.4":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz#78bc5d626a6642db3312d9d0f001f5e7639fde8c"
@@ -838,12 +1453,26 @@
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-template-literals@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.0.tgz#a8eced3a8e7b8e2d40ec4ec4548a45912630d302"
+  integrity sha512-Rd4Ic89hA/f7xUSJQk5PnC+4so50vBoBfxjdQAdvngwidM8jYIBVxBZ/sARxD4e0yMXRbJVDrYf7dyRtIIKT6Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-typeof-symbol@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz#9509f1a7eec31c4edbffe137c16cc33ff0bc5bfc"
   integrity sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-typeof-symbol@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.0.tgz#8b19a244c6f8c9d668dca6a6f754ad6ead1128f2"
+  integrity sha512-++V2L8Bdf4vcaHi2raILnptTBjGEFxn5315YU+e8+EqXIucA+q349qWngCLpUYqqv233suJ6NOienIVUpS9cqg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-typescript@^7.13.0":
   version "7.13.0"
@@ -869,6 +1498,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-unicode-escapes@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.0.tgz#1a354064b4c45663a32334f46fa0cf6100b5b1f3"
+  integrity sha512-VFi4dhgJM7Bpk8lRc5CMaRGlKZ29W9C3geZjt9beuzSUrlJxsNwX7ReLwaL6WEvsOf2EQkyIJEPtF8EXjB/g2A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
 "@babel/plugin-transform-unicode-regex@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz#e56d71f9282fac6db09c82742055576d5e6d80a8"
@@ -876,6 +1512,14 @@
   dependencies:
     "@babel/helper-create-regexp-features-plugin" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-unicode-regex@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.0.tgz#293b80950177c8c85aede87cef280259fb995402"
+  integrity sha512-jHLK4LxhHjvCeZDWyA9c+P9XH1sOxRd1RO9xMtDVRAOND/PczPqizEtVdx4TQF/wyPaewqpT+tgQFYMnN/P94A==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/polyfill@^7.11.5", "@babel/polyfill@^7.7.0":
   version "7.11.5"
@@ -885,7 +1529,87 @@
     core-js "^2.6.5"
     regenerator-runtime "^0.13.4"
 
-"@babel/preset-env@^7.12.0", "@babel/preset-env@^7.7.0":
+"@babel/preset-env@^7.16.4":
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.16.4.tgz#4f6ec33b2a3fe72d6bfdcdf3859500232563a2e3"
+  integrity sha512-v0QtNd81v/xKj4gNKeuAerQ/azeNn/G1B1qMLeXOcV8+4TWlD2j3NV1u8q29SDFBXx/NBq5kyEAO+0mpRgacjA==
+  dependencies:
+    "@babel/compat-data" "^7.16.4"
+    "@babel/helper-compilation-targets" "^7.16.3"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-validator-option" "^7.14.5"
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.16.2"
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.16.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.16.4"
+    "@babel/plugin-proposal-class-properties" "^7.16.0"
+    "@babel/plugin-proposal-class-static-block" "^7.16.0"
+    "@babel/plugin-proposal-dynamic-import" "^7.16.0"
+    "@babel/plugin-proposal-export-namespace-from" "^7.16.0"
+    "@babel/plugin-proposal-json-strings" "^7.16.0"
+    "@babel/plugin-proposal-logical-assignment-operators" "^7.16.0"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.16.0"
+    "@babel/plugin-proposal-numeric-separator" "^7.16.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.16.0"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.16.0"
+    "@babel/plugin-proposal-optional-chaining" "^7.16.0"
+    "@babel/plugin-proposal-private-methods" "^7.16.0"
+    "@babel/plugin-proposal-private-property-in-object" "^7.16.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.16.0"
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+    "@babel/plugin-syntax-class-properties" "^7.12.13"
+    "@babel/plugin-syntax-class-static-block" "^7.14.5"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+    "@babel/plugin-syntax-top-level-await" "^7.14.5"
+    "@babel/plugin-transform-arrow-functions" "^7.16.0"
+    "@babel/plugin-transform-async-to-generator" "^7.16.0"
+    "@babel/plugin-transform-block-scoped-functions" "^7.16.0"
+    "@babel/plugin-transform-block-scoping" "^7.16.0"
+    "@babel/plugin-transform-classes" "^7.16.0"
+    "@babel/plugin-transform-computed-properties" "^7.16.0"
+    "@babel/plugin-transform-destructuring" "^7.16.0"
+    "@babel/plugin-transform-dotall-regex" "^7.16.0"
+    "@babel/plugin-transform-duplicate-keys" "^7.16.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.16.0"
+    "@babel/plugin-transform-for-of" "^7.16.0"
+    "@babel/plugin-transform-function-name" "^7.16.0"
+    "@babel/plugin-transform-literals" "^7.16.0"
+    "@babel/plugin-transform-member-expression-literals" "^7.16.0"
+    "@babel/plugin-transform-modules-amd" "^7.16.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.16.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.16.0"
+    "@babel/plugin-transform-modules-umd" "^7.16.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.16.0"
+    "@babel/plugin-transform-new-target" "^7.16.0"
+    "@babel/plugin-transform-object-super" "^7.16.0"
+    "@babel/plugin-transform-parameters" "^7.16.3"
+    "@babel/plugin-transform-property-literals" "^7.16.0"
+    "@babel/plugin-transform-regenerator" "^7.16.0"
+    "@babel/plugin-transform-reserved-words" "^7.16.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.16.0"
+    "@babel/plugin-transform-spread" "^7.16.0"
+    "@babel/plugin-transform-sticky-regex" "^7.16.0"
+    "@babel/plugin-transform-template-literals" "^7.16.0"
+    "@babel/plugin-transform-typeof-symbol" "^7.16.0"
+    "@babel/plugin-transform-unicode-escapes" "^7.16.0"
+    "@babel/plugin-transform-unicode-regex" "^7.16.0"
+    "@babel/preset-modules" "^0.1.5"
+    "@babel/types" "^7.16.0"
+    babel-plugin-polyfill-corejs2 "^0.3.0"
+    babel-plugin-polyfill-corejs3 "^0.4.0"
+    babel-plugin-polyfill-regenerator "^0.3.0"
+    core-js-compat "^3.19.1"
+    semver "^6.3.0"
+
+"@babel/preset-env@^7.7.0":
   version "7.12.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.12.0.tgz#7d2d0c4f4a14ca0fd7d905a741070ab4745177b7"
   integrity sha512-jSIHvHSuF+hBUIrvA2/61yIzhH+ceLOXGLTH1nwPvQlso/lNxXsoE/nvrCzY5M77KRzhKegB1CvdhWPZmYDZ5A==
@@ -969,6 +1693,17 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
+"@babel/preset-modules@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.5.tgz#ef939d6e7f268827e1841638dc6ff95515e115d9"
+  integrity sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
+    "@babel/plugin-transform-dotall-regex" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    esutils "^2.0.2"
+
 "@babel/runtime@7.12.18":
   version "7.12.18"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.18.tgz#af137bd7e7d9705a412b3caaf991fe6aaa97831b"
@@ -991,6 +1726,15 @@
     "@babel/code-frame" "^7.12.13"
     "@babel/parser" "^7.12.13"
     "@babel/types" "^7.12.13"
+
+"@babel/template@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.0.tgz#d16a35ebf4cd74e202083356fab21dd89363ddd6"
+  integrity sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==
+  dependencies:
+    "@babel/code-frame" "^7.16.0"
+    "@babel/parser" "^7.16.0"
+    "@babel/types" "^7.16.0"
 
 "@babel/traverse@^7.10.4", "@babel/traverse@^7.7.0":
   version "7.12.0"
@@ -1022,6 +1766,21 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
+"@babel/traverse@^7.16.0":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.3.tgz#f63e8a938cc1b780f66d9ed3c54f532ca2d14787"
+  integrity sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==
+  dependencies:
+    "@babel/code-frame" "^7.16.0"
+    "@babel/generator" "^7.16.0"
+    "@babel/helper-function-name" "^7.16.0"
+    "@babel/helper-hoist-variables" "^7.16.0"
+    "@babel/helper-split-export-declaration" "^7.16.0"
+    "@babel/parser" "^7.16.3"
+    "@babel/types" "^7.16.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.10.4", "@babel/types@^7.11.0", "@babel/types@^7.12.0", "@babel/types@^7.12.13", "@babel/types@^7.13.0":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.0.tgz#74424d2816f0171b4100f0ab34e9a374efdf7f80"
@@ -1038,6 +1797,14 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.0.tgz#db3b313804f96aadd0b776c4823e127ad67289ba"
+  integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
 "@ember-data/rfc395-data@^0.0.4":
@@ -1821,6 +2588,15 @@ babel-plugin-polyfill-corejs2@^0.1.4:
     "@babel/helper-define-polyfill-provider" "^0.1.5"
     semver "^6.1.1"
 
+babel-plugin-polyfill-corejs2@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz#407082d0d355ba565af24126fb6cb8e9115251fd"
+  integrity sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==
+  dependencies:
+    "@babel/compat-data" "^7.13.11"
+    "@babel/helper-define-polyfill-provider" "^0.3.0"
+    semver "^6.1.1"
+
 babel-plugin-polyfill-corejs3@^0.1.3:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.7.tgz#80449d9d6f2274912e05d9e182b54816904befd0"
@@ -1829,12 +2605,27 @@ babel-plugin-polyfill-corejs3@^0.1.3:
     "@babel/helper-define-polyfill-provider" "^0.1.5"
     core-js-compat "^3.8.1"
 
+babel-plugin-polyfill-corejs3@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.4.0.tgz#0b571f4cf3d67f911512f5c04842a7b8e8263087"
+  integrity sha512-YxFreYwUfglYKdLUGvIF2nJEsGwj+RhWSX/ije3D2vQPOXuyMLMtg/cCGMDpOA7Nd+MwlNdnGODbd2EwUZPlsw==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.3.0"
+    core-js-compat "^3.18.0"
+
 babel-plugin-polyfill-regenerator@^0.1.2:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.1.6.tgz#0fe06a026fe0faa628ccc8ba3302da0a6ce02f3f"
   integrity sha512-OUrYG9iKPKz8NxswXbRAdSwF0GhRdIEMTloQATJi4bDuFqrXaXcCUT/VGNrr8pBcjMh1RxZ7Xt9cytVJTJfvMg==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.1.5"
+
+babel-plugin-polyfill-regenerator@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz#9ebbcd7186e1a33e21c5e20cae4e7983949533be"
+  integrity sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.3.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -2737,6 +3528,17 @@ browserslist@^4.14.5, browserslist@^4.16.3:
     escalade "^3.1.1"
     node-releases "^1.1.70"
 
+browserslist@^4.17.5, browserslist@^4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.18.1.tgz#60d3920f25b6860eb917c6c7b185576f4d8b017f"
+  integrity sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==
+  dependencies:
+    caniuse-lite "^1.0.30001280"
+    electron-to-chromium "^1.3.896"
+    escalade "^3.1.1"
+    node-releases "^2.0.1"
+    picocolors "^1.0.0"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -2938,6 +3740,11 @@ caniuse-lite@^1.0.30001181:
   version "1.0.30001196"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001196.tgz#00518a2044b1abf3e0df31fadbe5ed90b63f4e64"
   integrity sha512-CPvObjD3ovWrNBaXlAIGWmg2gQQuJ5YhuciUOjPRox6hIQttu8O+b51dx6VIpIY9ESd2d0Vac1RKpICdG4rGUg==
+
+caniuse-lite@^1.0.30001280:
+  version "1.0.30001285"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz#fe1e52229187e11d6670590790d669b9e03315b7"
+  integrity sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==
 
 capture-exit@^1.1.0, capture-exit@^1.2.0:
   version "1.2.0"
@@ -3396,6 +4203,14 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+core-js-compat@^3.18.0, core-js-compat@^3.19.1:
+  version "3.19.3"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.19.3.tgz#de75e5821c5ce924a0a1e7b7d5c2cb973ff388aa"
+  integrity sha512-59tYzuWgEEVU9r+SRgceIGXSSUn47JknoiXW6Oq7RW8QHjXWz3/vp8pa7dbtuVu40sewz3OP3JmQEcDdztrLhA==
+  dependencies:
+    browserslist "^4.18.1"
+    semver "7.0.0"
+
 core-js-compat@^3.6.2:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.6.4.tgz#938476569ebb6cda80d339bcf199fae4f16fff17"
@@ -3723,6 +4538,11 @@ electron-to-chromium@^1.3.649:
   version "1.3.682"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.682.tgz#f4b5c8d4479df96b61e508a721d6c32c1262ef23"
   integrity sha512-zok2y37qR00U14uM6qBz/3iIjWHom2eRfC2S1StA0RslP7x34jX+j4mxv80t8OEOHLJPVG54ZPeaFxEI7gPrwg==
+
+electron-to-chromium@^1.3.896:
+  version "1.4.12"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.12.tgz#5f73d1278c6205fc41d7a0ebd75563046b77c5d8"
+  integrity sha512-zjfhG9Us/hIy8AlQ5OzfbR/C4aBv1Dg/ak4GX35CELYlJ4tDAtoEcQivXvyBdqdNQ+R6PhlgQqV8UNPJmhkJog==
 
 ember-assign-polyfill@^2.6.0:
   version "2.6.0"
@@ -7420,6 +8240,11 @@ node-releases@^1.1.70:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
   integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
 
+node-releases@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
+  integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
+
 node-watch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/node-watch/-/node-watch-0.6.1.tgz#b9874111ce9f5841b1c7596120206c7b825be0e9"
@@ -7951,6 +8776,11 @@ pathval@^1.1.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
 picomatch@^2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
@@ -8264,10 +9094,22 @@ regenerate-unicode-properties@^8.2.0:
   dependencies:
     regenerate "^1.4.0"
 
+regenerate-unicode-properties@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz#54d09c7115e1f53dc2314a974b32c1c344efe326"
+  integrity sha512-3E12UeNSPfjrgwjkR81m5J7Aw/T55Tu7nUyZVQYCKEOs+2dkxEY+DpPtZzO4YruuiPb7NkYLVcyJC4+zCbk5pA==
+  dependencies:
+    regenerate "^1.4.2"
+
 regenerate@^1.2.1, regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
+
+regenerate@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
+  integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
 regenerator-runtime@^0.10.5:
   version "0.10.5"
@@ -8347,6 +9189,18 @@ regexpu-core@^4.7.0:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.2.0"
 
+regexpu-core@^4.7.1:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.8.0.tgz#e5605ba361b67b1718478501327502f4479a98f0"
+  integrity sha512-1F6bYsoYiz6is+oz70NWur2Vlh9KWtswuRuzJOfeYUrfPX2o8n74AnUVaOGDbUqVGO9fNHu48/pjJO4sNVwsOg==
+  dependencies:
+    regenerate "^1.4.2"
+    regenerate-unicode-properties "^9.0.0"
+    regjsgen "^0.5.2"
+    regjsparser "^0.7.0"
+    unicode-match-property-ecmascript "^2.0.0"
+    unicode-match-property-value-ecmascript "^2.0.0"
+
 registry-auth-token@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.4.0.tgz#d7446815433f5d5ed6431cd5dca21048f66b397e"
@@ -8372,6 +9226,11 @@ regjsgen@^0.5.1:
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.1.tgz#48f0bf1a5ea205196929c0d9798b42d1ed98443c"
   integrity sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==
 
+regjsgen@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.2.tgz#92ff295fb1deecbf6ecdab2543d207e91aa33733"
+  integrity sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==
+
 regjsparser@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
@@ -8383,6 +9242,13 @@ regjsparser@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.4.tgz#a769f8684308401a66e9b529d2436ff4d0666272"
   integrity sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==
+  dependencies:
+    jsesc "~0.5.0"
+
+regjsparser@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.7.0.tgz#a6b667b54c885e18b52554cb4960ef71187e9968"
+  integrity sha512-A4pcaORqmNMDVwUjWoTzuhwMGpP+NykpfqAsEgI1FSH/EzC7lrN5TMd+kN8YCovX+jMpu8eaqXgXPCa0g8FQNQ==
   dependencies:
     jsesc "~0.5.0"
 
@@ -9628,6 +10494,11 @@ unicode-canonical-property-names-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
   integrity sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==
 
+unicode-canonical-property-names-ecmascript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz#301acdc525631670d39f6146e0e77ff6bbdebddc"
+  integrity sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==
+
 unicode-match-property-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz#8ed2a32569961bce9227d09cd3ffbb8fed5f020c"
@@ -9636,15 +10507,33 @@ unicode-match-property-ecmascript@^1.0.4:
     unicode-canonical-property-names-ecmascript "^1.0.4"
     unicode-property-aliases-ecmascript "^1.0.4"
 
+unicode-match-property-ecmascript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz#54fd16e0ecb167cf04cf1f756bdcc92eba7976c3"
+  integrity sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==
+  dependencies:
+    unicode-canonical-property-names-ecmascript "^2.0.0"
+    unicode-property-aliases-ecmascript "^2.0.0"
+
 unicode-match-property-value-ecmascript@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz#0d91f600eeeb3096aa962b1d6fc88876e64ea531"
   integrity sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==
 
+unicode-match-property-value-ecmascript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz#1a01aa57247c14c568b89775a54938788189a714"
+  integrity sha512-7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==
+
 unicode-property-aliases-ecmascript@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz#dd57a99f6207bedff4628abefb94c50db941c8f4"
   integrity sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==
+
+unicode-property-aliases-ecmascript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8"
+  integrity sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Historically, we only add the `@babel/plugin-proposal-class-properties` so that we make sure the ordering is right with the decorators proposal (otherwise, it can end up compiling in the wrong order). With a recent version of `@babel/preset-env` and, transitively, `caniuse-lite`, this resulted in cases where we added that plugin but *not* related plugins for private class properties, which in turn triggered a Babel assertion about not adding the properties together as appropriate when the caniuse database (correctly) reported that .

The fix is:

1.  Bump to a more recent version of `@babel/preset-env`, which comes with a correspondingly bumped version of `caniuse-lite`, which in turn correctly understands what the latest versions of targeted browsers are.

2.  Include in `ember-cli-babel` itself a check for whether we even *need* to add the plugin, and only provide it when the provided `targets` indicate that they require it.

Resolves #419