### PR TITLE
introduce cacheKeyForTree to avoid running treeForX multiple times

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const path = require('path');
 const getBabelOptions = require('./lib/get-babel-options');
 const findApp = require('./lib/find-app');
 const emberPlugins = require('./lib/ember-plugins');
+const cacheKeyForTree = require('calculate-cache-key-for-tree');
 
 const APP_BABEL_RUNTIME_VERSION = new WeakMap();
 const PROJECTS_WITH_VALID_EMBER_CLI = new WeakSet();
@@ -271,6 +272,17 @@ module.exports = {
     });
 
     return polyfillTree;
+  },
+
+  cacheKeyForTree(treeType) {
+    if (treeType === 'addon') {
+      let isRootBabel = this.parent === this.project;
+      let shouldIncludeHelpers = isRootBabel && _shouldIncludeHelpers(this._getAppOptions(), this);
+
+      return cacheKeyForTree('addon', this, [shouldIncludeHelpers]);
+    }
+
+    return cacheKeyForTree(treeType, this);
   },
 
   included: function(app) {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "broccoli-debug": "^0.6.4",
     "broccoli-funnel": "^2.0.2",
     "broccoli-source": "^2.1.2",
+    "calculate-cache-key-for-tree": "^2.0.0",
     "clone": "^2.1.2",
     "ember-cli-babel-plugin-helpers": "^1.1.1",
     "ember-cli-version-checker": "^4.1.0",
@@ -71,7 +72,6 @@
   "devDependencies": {
     "babel-eslint": "^10.1.0",
     "broccoli-test-helper": "^1.4.0",
-    "calculate-cache-key-for-tree": "^2.0.0",
     "chai": "^4.1.2",
     "co": "^4.6.0",
     "common-tags": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "devDependencies": {
     "babel-eslint": "^10.1.0",
     "broccoli-test-helper": "^1.4.0",
+    "calculate-cache-key-for-tree": "^2.0.0",
     "chai": "^4.1.2",
     "co": "^4.6.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2860,6 +2860,13 @@ calculate-cache-key-for-tree@^1.0.0:
   dependencies:
     json-stable-stringify "^1.0.1"
 
+calculate-cache-key-for-tree@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/calculate-cache-key-for-tree/-/calculate-cache-key-for-tree-2.0.0.tgz#7ac57f149a4188eacb0a45b210689215d3fef8d6"
+  integrity sha512-Quw8a6y8CPmRd6eU+mwypktYCwUcf8yVFIRbNZ6tPQEckX9yd+EBVEPC/GSZZrMWH9e7Vz4pT7XhpmyApRByLQ==
+  dependencies:
+    json-stable-stringify "^1.0.1"
+
 call-bind@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"


### PR DESCRIPTION
We have a big monorepo and got to a point, where our build times are unacceptably slow. Can easily be 2-3mins to start an app. We've started to do some investigation to try and figure our what might be an issue. `cacheKeyForTree` and [this RFC](https://emberjs.github.io/rfcs/0090-addon-tree-caching.html) sparked my interest. After adding cache for all our internal addons, we've got in some cases up to 50% speed up. Next on our list is to identify all community addons that might be missing caching. `ember-cli-babel` is more/less the first one, as it might have quite a big impact.

Will use this command to show difference before an after
```
DEBUG=ember-cli:addon:cache-key-for-tree ember s &> capture-cache-key-debug.txt
```

**Log before adding a cache**
393 lines of cache opt-out. `Build successful (135792ms)`

<details>
  <summary>Show output</summary>
  
  ```
[treeFor(<internal addon, redacted> - addon-test-support) -> treeFor(<internal addon, redacted> - addon-test-support) -> treeFor(ember-cli-page-object - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(<internal addon, redacted> - addon-test-support) -> treeFor(ember-cli-page-object - addon-test-support) -> treeFor(ember-native-dom-helpers - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(@ember/test-helpers - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(<internal addon, redacted> - addon-test-support) -> treeFor(<internal addon, redacted> - addon-test-support) -> treeFor(ember-cli-page-object - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(<internal addon, redacted> - addon-test-support) -> treeFor(ember-cli-page-object - addon-test-support) -> treeFor(ember-native-dom-helpers - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(ember-sinon-qunit - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(ember-qunit - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(qunit-dom - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(<internal addon, redacted> - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(@ember/string - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(@ember/test-waiters - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(<internal addon, redacted>  - vendor) -> treeFor(moment - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(moment - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(moment - vendor) -> treeFor(ember-get-config - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-moment - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-moment - vendor) -> treeFor(ember-macro-helpers - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-browser-services - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-browser-services - vendor) -> treeFor(ember-window-mock - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(moment - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(moment - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-cli-pretender - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-cli-pretender - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-cli-sentry - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-cli-sentry - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-concurrency - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-concurrency - vendor) -> treeFor(ember-maybe-import-regenerator - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-concurrency - vendor) -> treeFor(ember-maybe-import-regenerator - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-faker - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-faker - vendor) -> treeFor(ember-cli-node-assets - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-fetch - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-inflector - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-intl - vendor) -> treeFor(ember-auto-import - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-intl - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-lodash - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-mobiledoc-text-renderer - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-useragent - vendor) -> treeFor(ember-auto-import - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-useragent - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cached-decorator-polyfill - vendor) -> treeFor(ember-cache-primitive-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-cached-decorator-polyfill - vendor) -> treeFor(ember-cache-primitive-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cached-decorator-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-auto-import - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-postcss - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(tracked-built-ins - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(tracked-built-ins - vendor) -> treeFor(tracked-maps-and-sets - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(@ember/render-modifiers - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(@ember/render-modifiers - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(@ember/render-modifiers - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(@glimmer/component - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(@html-next/vertical-collection - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(@html-next/vertical-collection - vendor) -> treeFor(ember-raf-scheduler - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-animated - vendor) -> treeFor(ember-named-arguments-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-animated - vendor) -> treeFor(ember-angle-bracket-invocation-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-animated - vendor) -> treeFor(ember-angle-bracket-invocation-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-animated - vendor) -> treeFor(ember-auto-import - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-animated - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(@ember-decorators/component - vendor) -> treeFor(@ember-decorators/utils - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-decorators - vendor) -> treeFor(@ember-decorators/component - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-decorators - vendor) -> treeFor(@ember-decorators/object - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-animated - vendor) -> treeFor(ember-decorators - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(@embroider/util - vendor) -> treeFor(@embroider/macros - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-element-helper - vendor) -> treeFor(@embroider/util - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-animated - vendor) -> treeFor(ember-element-helper - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-animated - vendor) -> treeFor(ember-maybe-import-regenerator - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-animated - vendor) -> treeFor(ember-maybe-import-regenerator - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-css-modules - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-changeset-conditional-validations - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-changeset - vendor) -> treeFor(@embroider/macros - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-changeset - vendor) -> treeFor(ember-auto-import - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-changeset - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-changeset-validations - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-changeset-validations - vendor) -> treeFor(ember-validators - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-cli-flash - vendor) -> treeFor(@ember/render-modifiers - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-cli-flash - vendor) -> treeFor(@ember/render-modifiers - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(@ember/render-modifiers - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-flash - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-cli-flash - vendor) -> treeFor(ember-runtime-enumerable-includes-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-page-object - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-page-object - vendor) -> treeFor(ember-cli-node-assets - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-cli-page-object - vendor) -> treeFor(ember-native-dom-helpers - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-string-helpers - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-composable-helpers - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-concurrency-async - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-concurrency-decorators - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-concurrency-ts - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-could-get-used-to-this - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-focus-trap - vendor) -> treeFor(ember-auto-import - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-focus-trap - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-focus-trap - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-focus-trap - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-keyboard - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-keyboard - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-keyboard - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-destroyable-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-modifier - vendor) -> treeFor(ember-destroyable-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-keyboard - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-modifier - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-power-calendar - vendor) -> treeFor(ember-assign-helper - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-power-calendar - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-power-calendar - vendor) -> treeFor(ember-cli-element-closest-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-power-calendar - vendor) -> treeFor(ember-cli-element-closest-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-power-calendar - vendor) -> treeFor(ember-truth-helpers - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-power-calendar-moment - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-power-calendar-moment - vendor) -> treeFor(moment - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-power-calendar-moment - vendor) -> treeFor(moment - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-resize-observer-service - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-sortable - vendor) -> treeFor(@ember/render-modifiers - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-sortable - vendor) -> treeFor(@ember/render-modifiers - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(@ember/render-modifiers - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-sortable - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-sortable - vendor) -> treeFor(ember-test-selectors - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-sortable - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-sortable - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-destroyable-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-modifier - vendor) -> treeFor(ember-destroyable-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-sortable - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-modifier - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-text-measurer - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-url-hash-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-uuid - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(tracked-toolbox - vendor) -> treeFor(ember-cache-primitive-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(tracked-toolbox - vendor) -> treeFor(ember-cache-primitive-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(tracked-toolbox - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-aria-utilities - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-aria-utilities - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-aria-utilities - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-destroyable-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-modifier - vendor) -> treeFor(ember-destroyable-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-aria-utilities - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-modifier - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(@embroider/macros - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-resource-tasks - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-resource-tasks - vendor) -> treeFor(ember-destroyable-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-resource-tasks - vendor) -> treeFor(ember-destroyable-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(@ember/test-helpers - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(@ember/test-helpers - vendor) -> treeFor(ember-destroyable-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(@ember/test-helpers - vendor) -> treeFor(ember-destroyable-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-cli-app-version - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-cli-deploy-cs - vendor) -> treeFor(ember-auto-import - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-cli-deploy-cs - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-cli-deploy-cs - vendor) -> treeFor(ember-cli-deploy-brotli - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-cli-deprecation-workflow - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-auto-import - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-lifecycle-component - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-load-initializers - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-maybe-import-regenerator - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-maybe-import-regenerator - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-resolver - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-sinon-qunit - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-sinon-qunit - vendor) -> treeFor(ember-sinon - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-sinon-qunit - vendor) -> treeFor(ember-sinon - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-source - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-source - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-statecharts - vendor) -> treeFor(ember-auto-import - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-statecharts - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-statecharts - vendor) -> treeFor(ember-usable - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-validity-modifier - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-validity-modifier - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-validity-modifier - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-destroyable-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-modifier - vendor) -> treeFor(ember-destroyable-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-validity-modifier - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-modifier - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(fully-qualified-sourcemap-urls - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-qunit - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-qunit - vendor) -> treeFor(ember-auto-import - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-qunit - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-qunit - vendor) -> treeFor(ember-cli-test-loader - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(qunit-dom - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(qunit-dom - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(@embroider/macros - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-babel - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(@ember/string - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(@ember/test-waiters - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(moment - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(moment - addon) -> treeFor(ember-get-config - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(moment - addon) -> treeFor(ember-get-config - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-moment - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-moment - addon) -> treeFor(ember-macro-helpers - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-browser-services - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-browser-services - addon) -> treeFor(ember-window-mock - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-cli-pretender - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-cli-sentry - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-concurrency - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-concurrency - addon) -> treeFor(ember-maybe-import-regenerator - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-faker - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-fetch - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-inflector - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-intl - addon) -> treeFor(ember-auto-import - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-intl - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-lodash - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-lodash - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-mobiledoc-text-renderer - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-useragent - addon) -> treeFor(ember-auto-import - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-useragent - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-cached-decorator-polyfill - addon) -> treeFor(ember-cache-primitive-polyfill - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cached-decorator-polyfill - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-auto-import - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-postcss - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(tracked-built-ins - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(tracked-built-ins - addon) -> treeFor(tracked-maps-and-sets - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(@ember/render-modifiers - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(@ember/render-modifiers - addon) -> treeFor(ember-modifier-manager-polyfill - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(@glimmer/component - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(@glimmer/component - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(@html-next/vertical-collection - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(@html-next/vertical-collection - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(@html-next/vertical-collection - addon) -> treeFor(ember-raf-scheduler - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-animated - addon) -> treeFor(ember-named-arguments-polyfill - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-animated - addon) -> treeFor(ember-angle-bracket-invocation-polyfill - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-animated - addon) -> treeFor(ember-angle-bracket-invocation-polyfill - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-animated - addon) -> treeFor(ember-auto-import - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-animated - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(@ember-decorators/component - addon) -> treeFor(@ember-decorators/utils - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-decorators - addon) -> treeFor(@ember-decorators/component - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-decorators - addon) -> treeFor(@ember-decorators/object - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-animated - addon) -> treeFor(ember-decorators - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(@embroider/util - addon) -> treeFor(@embroider/macros - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-element-helper - addon) -> treeFor(@embroider/util - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-animated - addon) -> treeFor(ember-element-helper - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-animated - addon) -> treeFor(ember-maybe-import-regenerator - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-css-modules - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-changeset-conditional-validations - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-changeset - addon) -> treeFor(@embroider/macros - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-changeset - addon) -> treeFor(ember-auto-import - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-changeset - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-changeset-validations - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-changeset-validations - addon) -> treeFor(ember-get-config - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-changeset-validations - addon) -> treeFor(ember-get-config - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-changeset-validations - addon) -> treeFor(ember-validators - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-cli-flash - addon) -> treeFor(@ember/render-modifiers - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-flash - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-cli-flash - addon) -> treeFor(ember-runtime-enumerable-includes-polyfill - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-page-object - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-cli-page-object - addon) -> treeFor(ember-native-dom-helpers - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-string-helpers - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-string-helpers - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-composable-helpers - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-composable-helpers - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-concurrency-async - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-concurrency-decorators - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-concurrency-ts - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-could-get-used-to-this - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-focus-trap - addon) -> treeFor(ember-auto-import - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-focus-trap - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-keyboard - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-keyboard - addon) -> treeFor(ember-modifier - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-modifier - addon) -> treeFor(ember-destroyable-polyfill - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-modifier - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-power-calendar - addon) -> treeFor(ember-assign-helper - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-power-calendar - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-power-calendar - addon) -> treeFor(ember-cli-element-closest-polyfill - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-power-calendar - addon) -> treeFor(ember-truth-helpers - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-power-calendar-moment - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-power-calendar-moment - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-resize-observer-service - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-sortable - addon) -> treeFor(@ember/render-modifiers - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-sortable - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-sortable - addon) -> treeFor(ember-test-selectors - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-sortable - addon) -> treeFor(ember-get-config - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-sortable - addon) -> treeFor(ember-get-config - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-sortable - addon) -> treeFor(ember-modifier - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-text-measurer - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-url-hash-polyfill - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-uuid - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(tracked-toolbox - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-composable-helpers - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-composable-helpers - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-resources - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-aria-utilities - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-aria-utilities - addon) -> treeFor(ember-modifier - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-resources - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(@embroider/macros - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-resource-tasks - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(@ember/test-helpers - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(@glimmer/component - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(@glimmer/component - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-cli-app-version - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-cli-deploy-cs - addon) -> treeFor(ember-auto-import - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-cli-deploy-cs - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-cli-deploy-cs - addon) -> treeFor(ember-cli-deploy-brotli - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-auto-import - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(@glimmer/component - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(@glimmer/component - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-string-helpers - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-string-helpers - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-composable-helpers - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-composable-helpers - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-lifecycle-component - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-load-initializers - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-maybe-import-regenerator - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-resolver - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-sinon-qunit - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-sinon-qunit - addon) -> treeFor(ember-sinon - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-source - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-statecharts - addon) -> treeFor(ember-auto-import - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-statecharts - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-statecharts - addon) -> treeFor(ember-usable - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-validity-modifier - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-validity-modifier - addon) -> treeFor(ember-modifier - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(fully-qualified-sourcemap-urls - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-qunit - addon) -> treeFor(ember-auto-import - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-qunit - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(ember-qunit - addon) -> treeFor(ember-cli-test-loader - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(qunit-dom - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(@glimmer/component - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(@glimmer/component - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(@glimmer/component - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(@glimmer/component - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-resources - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(@embroider/macros - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-resources - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-babel - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - public) -> treeFor(<internal addon, redacted>  - public) -> treeFor(moment - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted>  - public) -> treeFor(moment - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted>  - public) -> treeFor(ember-faker - public) -> treeFor(ember-cli-node-assets - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - public) -> treeFor(ember-cli-page-object - public) -> treeFor(ember-cli-node-assets - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - public) -> treeFor(ember-power-calendar-moment - public) -> treeFor(moment - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - public) -> treeFor(<internal addon, redacted> - public) -> treeFor(ember-resources - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - public) -> treeFor(ember-resources - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - public) -> treeFor(<internal addon, redacted> - public) -> treeFor(ember-resources - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - public) -> treeFor(ember-resources - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(@html-next/vertical-collection - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(ember-animated - app) -> treeFor(ember-angle-bracket-invocation-polyfill - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-cli-string-helpers - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-composable-helpers - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-composable-helpers - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-resources - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(ember-resources - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-cli-string-helpers - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-composable-helpers - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-resources - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(ember-resources - app)] Opting out due to: modified methods: treeForApp
```

</details>


**Log after adding a cache**
84 lines of cache opt-out. `Build successful (101886ms)`

<details>
  <summary>Show output</summary>
  
  ```
[treeFor(<internal addon, redacted> - addon-test-support) -> treeFor(<internal addon, redacted> - addon-test-support) -> treeFor(ember-cli-page-object - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(<internal addon, redacted> - addon-test-support) -> treeFor(ember-cli-page-object - addon-test-support) -> treeFor(ember-native-dom-helpers - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(@ember/test-helpers - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(<internal addon, redacted> - addon-test-support) -> treeFor(<internal addon, redacted> - addon-test-support) -> treeFor(ember-cli-page-object - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(<internal addon, redacted> - addon-test-support) -> treeFor(ember-cli-page-object - addon-test-support) -> treeFor(ember-native-dom-helpers - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(ember-sinon-qunit - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(ember-qunit - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(qunit-dom - addon-test-support)] Opting out due to: modified methods: treeForAddonTestSupport
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(<internal addon, redacted> - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(<internal addon, redacted>  - vendor) -> treeFor(moment - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(moment - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-cli-pretender - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-cli-sentry - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-concurrency - vendor) -> treeFor(ember-maybe-import-regenerator - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - vendor) -> treeFor(ember-faker - vendor) -> treeFor(ember-cli-node-assets - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor) -> treeFor(<internal addon, redacted> - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cached-decorator-polyfill - vendor) -> treeFor(ember-cache-primitive-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(@ember/render-modifiers - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-animated - vendor) -> treeFor(ember-angle-bracket-invocation-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-animated - vendor) -> treeFor(ember-maybe-import-regenerator - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-cli-flash - vendor) -> treeFor(@ember/render-modifiers - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-cli-page-object - vendor) -> treeFor(ember-cli-node-assets - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-focus-trap - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-keyboard - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-destroyable-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-keyboard - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-power-calendar - vendor) -> treeFor(ember-cli-element-closest-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-power-calendar-moment - vendor) -> treeFor(moment - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-sortable - vendor) -> treeFor(@ember/render-modifiers - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-sortable - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-destroyable-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-sortable - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(tracked-toolbox - vendor) -> treeFor(ember-cache-primitive-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-aria-utilities - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-destroyable-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-aria-utilities - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted> - vendor) -> treeFor(ember-resource-tasks - vendor) -> treeFor(ember-destroyable-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(@ember/test-helpers - vendor) -> treeFor(ember-destroyable-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-cli-deprecation-workflow - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-maybe-import-regenerator - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-sinon-qunit - vendor) -> treeFor(ember-sinon - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-source - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-validity-modifier - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-destroyable-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-validity-modifier - vendor) -> treeFor(ember-modifier - vendor) -> treeFor(ember-modifier-manager-polyfill - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(ember-qunit - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(qunit-dom - vendor)] Opting out due to: modified methods: treeForVendor
[treeFor(<internal addon, redacted>  - addon) -> treeFor(moment - addon) -> treeFor(ember-get-config - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - addon) -> treeFor(ember-lodash - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(@glimmer/component - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(@html-next/vertical-collection - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-animated - addon) -> treeFor(ember-angle-bracket-invocation-polyfill - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-changeset-validations - addon) -> treeFor(ember-get-config - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-string-helpers - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-composable-helpers - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-power-calendar-moment - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-sortable - addon) -> treeFor(ember-get-config - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-composable-helpers - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-resources - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-resources - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(@glimmer/component - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(@glimmer/component - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-cli-string-helpers - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-composable-helpers - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(@glimmer/component - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(@glimmer/component - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(<internal addon, redacted> - addon) -> treeFor(ember-resources - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted> - addon) -> treeFor(ember-resources - addon)] Opting out due to: modified methods: treeForAddon
[treeFor(<internal addon, redacted>  - public) -> treeFor(<internal addon, redacted>  - public) -> treeFor(moment - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted>  - public) -> treeFor(moment - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted>  - public) -> treeFor(ember-faker - public) -> treeFor(ember-cli-node-assets - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - public) -> treeFor(ember-cli-page-object - public) -> treeFor(ember-cli-node-assets - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - public) -> treeFor(ember-power-calendar-moment - public) -> treeFor(moment - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - public) -> treeFor(<internal addon, redacted> - public) -> treeFor(ember-resources - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - public) -> treeFor(ember-resources - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - public) -> treeFor(<internal addon, redacted> - public) -> treeFor(ember-resources - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - public) -> treeFor(ember-resources - public)] Opting out due to: modified methods: treeForPublic
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(@html-next/vertical-collection - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(ember-animated - app) -> treeFor(ember-angle-bracket-invocation-polyfill - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-cli-string-helpers - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-composable-helpers - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-composable-helpers - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-resources - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(ember-resources - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-cli-string-helpers - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-composable-helpers - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(<internal addon, redacted> - app) -> treeFor(ember-resources - app)] Opting out due to: modified methods: treeForApp
[treeFor(<internal addon, redacted> - app) -> treeFor(ember-resources - app)] Opting out due to: modified methods: treeForApp
```


</details>

After this change, we've got ~30% increase~ some increase (after more extensive testing) in initial build time. We'll try to measure when/if we'll get to zero cache-miss.

I am curious to ask for feedback and see if we are good to move with that cache key addition?

As a side note:
Seems like a lot of addons that we use don't implement `cacheKeyForTree`, maybe it is not well knows for addon authors? Feels like some internal lint for ember-cli(?-babel) for addons could be useful, and that addon authors have to explicitly tell, that they _don't need_ the cache, rather than be in the dark that by adding treeForX they've opted out of cache.