### PR TITLE
Configure `loose` option for all class property plugins

### DIFF
--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -383,7 +383,10 @@ function _addClassProperties(addPlugin, plugins, options, config, parent, projec
   );
   addPlugin(
     plugins,
-    [require.resolve("@babel/plugin-proposal-private-methods")],
+    [
+      require.resolve("@babel/plugin-proposal-private-methods"),
+      { loose: options.loose || false }
+    ],
     _buildClassFeaturePluginConstraints(
       {
         after: ["@babel/plugin-proposal-decorators"],
@@ -395,7 +398,10 @@ function _addClassProperties(addPlugin, plugins, options, config, parent, projec
   );
   addPlugin(
     plugins,
-    [require.resolve("@babel/plugin-proposal-private-property-in-object")],
+    [
+      require.resolve("@babel/plugin-proposal-private-property-in-object"),
+      { loose: options.loose || false }
+    ],
     _buildClassFeaturePluginConstraints(
       {
         after: ["@babel/plugin-proposal-decorators"],


### PR DESCRIPTION
Found this regression [here](https://github.com/tracked-tools/tracked-built-ins/runs/4555001714?check_suite_focus=true#step:7:87): all class property proposals have to match their `{ loose: ... }` value. Confirmed via tracked-built-ins locally that without this, it breaks, and with it, it passes. (Unclear why our tests for private class properties didn't catch it!)

<details><summary>terminal output from building it locally</summary>

```
~/d/t/tracked-built-ins on  latest-ember-cli-babel via  v14.18.1
❯ yarn link ember-cli-babel
yarn link v1.22.10
success Using linked package for "ember-cli-babel".
✨  Done in 0.18s.

~/d/t/tracked-built-ins on  latest-ember-cli-babel via  v14.18.1
❯ ember build
Environment: development
⠦ building... [Babel: @ember/test-waiters > applyPatches]Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
to the "plugins" section of your Babel config.
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-property-in-object.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
cleaning up...
Built project successfully. Stored in "dist/".
⏎

~/d/t/tracked-built-ins on  latest-ember-cli-babel via  v14.18.1 took 22s
❯ yarn unlink ember-cli-babel
yarn unlink v1.22.10
success Removed linked package "ember-cli-babel".
info You will need to run `yarn install --force` to re-install the package that was linked.
✨  Done in 0.04s.

~/d/t/tracked-built-ins on  latest-ember-cli-babel via  v14.18.1
❯ yarn install --force
yarn install v1.22.10
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
warning "ember-source > @babel/plugin-transform-block-scoping@7.16.5" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "@ember/test-helpers > ember-destroyable-polyfill > ember-compatibility-helpers > babel-plugin-debug-macros@0.2.0" has unmet peer dependency "@babel/core@^7.0.0-beta.42".
warning "@glimmer/component > ember-cli-typescript > @babel/plugin-transform-typescript@7.5.5" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "ember-load-initializers > ember-cli-typescript > @babel/plugin-transform-typescript@7.4.5" has unmet peer dependency "@babel/core@^7.0.0-0".
[5/5] 🔨  Rebuilding all packages...
success Saved lockfile.
✨  Done in 12.11s.

~/d/t/tracked-built-ins on  latest-ember-cli-babel via  v14.18.1 took 12s
❯ ember build
Environment: development
cleaning up...
Build Error (broccoli-persistent-filter:Babel > [Babel: ember-source]) in @ember/-internals/bootstrap/index.js

/Users/ckrycho/dev/tracked-tools/tracked-built-ins/@ember/-internals/bootstrap/index.js: 'loose' mode configuration must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled).


Stack Trace and Error Report: /var/folders/bw/k3jm2wf96p390m_k4jmhwm5c001321/T/error.dump.d074ca813121fe44dd5417f7e58ccfb5.log
```

</details>