### PR TITLE
Fix missing babel polyfill in vendor tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,7 +275,9 @@ module.exports = {
   },
 
   cacheKeyForTree(treeType) {
-    if (treeType === 'addon') {
+    if (treeType === 'vendor') {
+      return cacheKeyForTree('vendor', this, [this._shouldIncludePolyfill()]);
+    } else if (treeType === 'addon') {
       let isRootBabel = this.parent === this.project;
       let shouldIncludeHelpers = isRootBabel && _shouldIncludeHelpers(this._getAppOptions(), this);
 


### PR DESCRIPTION
I believe this is a fix for the mystery of the missing babel polyfill as reported in #429. It seems as though the culprit was the introduction of `cacheKeyForTree()` in #421.

Since our `treeForVendor()` conditionally adds in the babel polyfill we need to consider that condition when generating the cache key for vendor.

I verified this fixes the simple reproduction (new Ember app with the polyfill enabled in ember-cli-build) and it also fixes this same issue on a big app I have at work.

This is the first time I've gone under the covers of ember-cli-babel so I'm happy to be educated if there's a better strategy for fixing this.