### PR TITLE
Avoid transpiling class-properties as they are natively supported

### DIFF
--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -321,28 +321,8 @@ function _addDecoratorPlugins(plugins, options, config, parent, project) {
   } else {
     addPlugin(
       plugins,
-      [require.resolve("@babel/plugin-proposal-decorators"), { legacy: true }],
-      _buildClassFeaturePluginConstraints(
-        {
-          before: ["@babel/plugin-proposal-class-properties"],
-        },
-        config,
-        parent,
-        project
-      )
+      [require.resolve("@babel/plugin-proposal-decorators"), { legacy: true }]
     );
-  }
-
-  if (hasPlugin(plugins, "@babel/plugin-proposal-class-properties")) {
-    if (parent === project) {
-      project.ui.writeWarnLine(
-        `${_parentName(
-          parent
-        )} has added the class-properties plugin to its build, but ember-cli-babel provides these by default now! You can remove the transforms, or the addon that provided them, such as @ember-decorators/babel-transforms.`
-      );
-    }
-  } else {
-    _addClassProperties(addPlugin, plugins, options, config, parent, project);
   }
 
   if (hasPlugin(plugins, "babel-plugin-filter-imports")) {
@@ -365,54 +345,6 @@ function _addDecoratorPlugins(plugins, options, config, parent, project) {
   return plugins;
 }
 
-function _addClassProperties(addPlugin, plugins, options, config, parent, project) {
-  addPlugin(
-    plugins,
-    [
-      require.resolve("@babel/plugin-proposal-class-properties"),
-      { loose: options.loose || false }
-    ],
-    _buildClassFeaturePluginConstraints(
-      {
-        after: ["@babel/plugin-proposal-decorators"],
-      },
-      config,
-      parent,
-      project
-    )
-  );
-  addPlugin(
-    plugins,
-    [
-      require.resolve("@babel/plugin-proposal-private-methods"),
-      { loose: options.loose || false }
-    ],
-    _buildClassFeaturePluginConstraints(
-      {
-        after: ["@babel/plugin-proposal-decorators"],
-      },
-      config,
-      parent,
-      project
-    )
-  );
-  addPlugin(
-    plugins,
-    [
-      require.resolve("@babel/plugin-proposal-private-property-in-object"),
-      { loose: options.loose || false }
-    ],
-    _buildClassFeaturePluginConstraints(
-      {
-        after: ["@babel/plugin-proposal-decorators"],
-      },
-      config,
-      parent,
-      project
-    )
-  );
-}
-
 function _addTypeScriptPlugin(plugins, parent, project) {
   const { hasPlugin, addPlugin } = require("ember-cli-babel-plugin-helpers");
 
@@ -433,7 +365,6 @@ function _addTypeScriptPlugin(plugins, parent, project) {
       ],
       {
         before: [
-          "@babel/plugin-proposal-class-properties",
           "@babel/plugin-proposal-private-methods",
           "@babel/plugin-proposal-decorators",
         ],

--- a/lib/ember-plugins.js
+++ b/lib/ember-plugins.js
@@ -163,7 +163,6 @@ function _getProposalDecoratorsAndClassPlugins(config) {
   if (!config.shouldIgnoreDecoratorAndClassPlugins) {
     return [
       ["@babel/plugin-proposal-decorators", { legacy: true }],
-      ["@babel/plugin-proposal-class-properties"],
     ];
   }
 }


### PR DESCRIPTION
**This PR is incomplete** -- current status: babel problem

_goal_:  make babel do less:
tested at: https://github.com/NullVoxPopuli/babel-transpilation-tests
current problem: (all in babel, not ember-cli-babel) decorator plugin assumes class-properties plugin is needed (it's not)

This is not intended to be merged, but serves as something for folks to point their package.jsons at when they want to see if they can disable class-property transpilation across their whole app and addons.

hopefully: _class property transformation is not required for decorators_ .

(it used to be required tho).
There is an assertion / error that's added by the decorators plugin tho.

Upon manual removal in the above demo _everything still works fine_.

Here is the the test:

<details><summary>input</summary>

```js
function f(target, key, desc) {
  let oldGet = desc.get
  let oldInit = desc.initializer

  desc.get =() => {
    console.log('called f on ', key);
    return oldInit?.() || oldGet();
  }
}
class A {
  #a = 'hi';

  get #b() {
    return 'hello' + this.#a;
  }

  get c() { return this.#b; }

  @f g;

  @f h = 2;

  i = 3;
}

let a = new A();

console.log({ g: f.g, c: a.c, h: a.h, i: a.i });
```

</details>
<details><summary>output</summary>

remove lines which define g and h
```js
"use strict";

var _class, _descriptor, _descriptor2;

function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object.keys(descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object.defineProperty(target, property, desc); desc = null; } return desc; }

function _initializerWarningHelper(descriptor, context) { throw new Error('Decorating class property failed. Please ensure that ' + 'proposal-class-properties is enabled and runs after the decorators transform.'); }

function f(target, key, desc) {
  let oldGet = desc.get;
  let oldInit = desc.initializer;

  desc.get = () => {
    console.log('called f on ', key);
    return oldInit?.() || oldGet();
  };
}

let A = (_class = class A {
  #a = 'hi';

  get #b() {
    return 'hello' + this.#a;
  }

  get c() {
    return this.#b;
  }

  g = _initializerWarningHelper(_descriptor, this);
  h = _initializerWarningHelper(_descriptor2, this);
  i = 3;
}, (_descriptor = _applyDecoratedDescriptor(_class.prototype, "g", [f], {
  configurable: true,
  enumerable: true,
  writable: true,
  initializer: null
}), _descriptor2 = _applyDecoratedDescriptor(_class.prototype, "h", [f], {
  configurable: true,
  enumerable: true,
  writable: true,
  initializer: function () {
    return 2;
  }
})), _class);
let a = new A();
console.log({
  g: f.g,
  c: a.c,
  h: a.h,
  i: a.i
});

```

</details>



the goal of this effort is the following:
 - to reduce the amount of work babel is doing 
 - to use _one_ babel / ember-cli-babel instance for the whole app tree (the complexity brought by addons compliing themselves with their own ember-cli-babel has been problematic for app-land control).
 
 To do this, a consuming app must have _only one_ ember-cli-babel instance in the whole node_modules graph.
 
 Related issues:
  - https://github.com/babel/ember-cli-babel/issues/447
  - https://github.com/babel/ember-cli-babel/issues/446
  - https://github.com/babel/ember-cli-babel/issues/417
  - https://github.com/babel/ember-cli-babel/issues/447
 