### PR TITLE
Remove workaround for `@babel/helper-compilation-functions` bug that was fixed upstream

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ const {
 } = require("./lib/babel-options-util");
 
 const VersionChecker = require('ember-cli-version-checker');
-const clone = require('clone');
 const babel = require('@babel/core');
 const path = require('path');
 const getBabelOptions = require('./lib/get-babel-options');
@@ -332,14 +331,7 @@ module.exports = {
 
     let parser = require('@babel/helper-compilation-targets').default;
     if (typeof targets === 'object' && targets !== null) {
-      // babel version 7.10.0 introduced a change that mutates the input:
-      // https://github.com/babel/babel/pull/11500
-      // copy the object to guard against it, otherwise subsequent calls to
-      // _getTargets() will only have a mutated copy and lose all config from `config/targets.js`
-      // in the host application.
-      // PR to fix this upstream in babel: https://github.com/babel/babel/pull/11648
-      const copy = clone(targets);
-      return parser(copy);
+      return parser(targets);
     } else {
       return targets;
     }

--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -19,7 +19,6 @@ const terminateWorkerPool = require('./utils/terminate-workers');
 const path = require('path');
 const fs = require('fs');
 const rimraf = require('rimraf');
-const clone = require('clone');
 const {
   _shouldHandleTypeScript,
   _shouldIncludeHelpers,
@@ -134,15 +133,15 @@ describe('ember-cli-babel', function() {
           input.write({
             "foo.js": `import Component from '@glimmer/component';\nimport { tracked } from '@glimmer/tracking';\nexport default class Foo extends Component { @tracked thisIsTracked = true; }`,
           });
-  
+
           this.addon.project.targets = {
             browsers: ["last 2 chrome versions"],
           };
-  
+
           subject = this.addon.transpileTree(input.path(), {});
-  
+
           output = createBuilder(subject);
-  
+
           yield output.build();
           expect(output.read()["foo.js"]).not.to.include(
             "_initializerWarningHelper(_descriptor, this)"
@@ -1931,16 +1930,6 @@ describe('ember-cli-babel', function() {
 
       let pluginRequired = this.addon.isPluginRequired('transform-regenerator');
       expect(pluginRequired).to.be.false;
-    });
-
-    it('defensively copies `targets` to prevent @babel/helper-compilation-functions mutating it', function() {
-      let targets = {
-        browsers: ['last 2 Chrome versions']
-      };
-      this.addon.project.targets = clone(targets);
-
-      this.addon.isPluginRequired('transform-regenerator');
-      expect(this.addon.project.targets).to.deep.equal(targets);
     });
   });
 });


### PR DESCRIPTION
This removes a workaround that was added for a bug in `babel-helper-compilation-targets` that was fixed upstream and is included in the version that is required by this addon.

The bugfix in `babel-helpers-compilation-targets` was included in [`v7.10.2`](https://github.com/babel/babel/releases/tag/v7.10.2)

`ember-cli-babel` began requiring a version of `babel-helpers-compilation-targets` that includes the bugfix since [`v7.21.0`](https://github.com/babel/ember-cli-babel/releases/tag/v7.21.0)

---

- [Original bugfix workaround PR](https://github.com/babel/ember-cli-babel/pull/345)
- [Dependency upgrade PR](https://github.com/babel/ember-cli-babel/pull/354)
- [`ember-cli-babel@7.21.0` Release notes](https://github.com/babel/ember-cli-babel/releases/tag/v7.21.0)
- [`babel-compilation-targets@7.10.2` Release notes](https://github.com/babel/babel/releases/tag/v7.10.2)