### PR TITLE
Move `@babel/core` to `peerDependencies` to resolve peer dependency warnings and errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,10 @@
     "test:node": "mocha node-tests",
     "test:node:debug": "mocha debug node-tests"
   },
+  "peerDependencies": {
+    "@babel/core": "^7.12.0"
+  },
   "dependencies": {
-    "@babel/core": "^7.12.0",
     "@babel/helper-compilation-targets": "^7.12.0",
     "@babel/plugin-proposal-class-properties": "^7.16.5",
     "@babel/plugin-proposal-decorators": "^7.13.5",
@@ -73,6 +75,7 @@
     "semver": "^5.5.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.12.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
…confusion

Following the advice here: https://github.com/ember-cli/ember-cli/pull/9934#issuecomment-1210078896

The eventual perceived fix for users is that when using strict package managers (npm 8, yarn2+, pnpm, etc) is that when they are told to specify a missing peer, `@babel/core`, the `@babel/core` they specify will be the one used by ember-cli-babel.

`@babel/core` will eventually be added to the app and addon blueprints in https://github.com/ember-cli/ember-cli/pull/9934