### PR TITLE
Clarify how to set `enableTypeScriptTransform` in Ember apps, addons and engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,11 +351,6 @@ NOTE: Setting `enableTypeScriptTransform` to `true` does *not* enable
 type-checking. For integrated type-checking, you will need
 [`ember-cli-typescript`](https://ember-cli-typescript.com).
 
-NOTE: Setting `enableTypeScriptTransform` to `true` is not compatible with
-`ember-cli-typescript < 4.0` because of conflicting Babel plugin ordering
-constraints. It is also unnecessary because `ember-cli-typescript < 4.0`
-adds the TypeScript-Babel transform.
-
 ### Babel config usage
 
 If you want to use the existing babel config from your project instead of the auto-generated one from this addon, then you would need to *opt-in* by passing the config `useBabelConfig: true` as a child property of `ember-cli-babel` in your `ember-cli-build.js` file.

--- a/README.md
+++ b/README.md
@@ -242,35 +242,120 @@ module.exports = function(defaults) {
 
 #### Enabling TypeScript Transpilation
 
-The transform plugin required for Babel to transpile TypeScript will
-automatically be enabled when `ember-cli-typescript` >= 4.0 is installed.
+Babel needs a transform plugin in order to transpile TypeScript. When you
+install `ember-cli-typescript >= 4.0`, this plugin is automatically enabled.
 
-You can enable the TypeScript Babel transform manually *without*
-`ember-cli-typescript` by setting the `enableTypeScriptTransform` to `true`.
+If you don't want to install `ember-cli-typescript`, you can still enable
+the TypeScript-Babel transform. You will need to set `enableTypeScriptTransform`
+to `true` in select file(s).
 
-NOTE: Setting this option to `true` is not compatible with
-`ember-cli-typescript` < 4.0 because of conflicting Babel plugin ordering
-constraints and is unnecessary because `ember-cli-typescript` < 4.0 adds the
-TypeScript Babel transform itself.
 
-NOTE: Setting this option to `true` does *not* enable type-checking. For
-integrated type-checking, you will need
-[`ember-cli-typescript`](https://ember-cli-typescript.com).
-
-In an app, manually enabling the TypeScript transform would look like:
+<details>
+<summary>Apps</summary>
 
 ```js
-// ember-cli-build.js
-module.exports = function(defaults) {
-  let app = new EmberApp(defaults, {
+/* ember-cli-build.js */
+
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {
+    // Add options here
     'ember-cli-babel': {
-      enableTypeScriptTransform: true
-    }
+      enableTypeScriptTransform: true,
+    },
   });
 
   return app.toTree();
-}
+};
 ```
+
+</details>
+
+
+<details>
+<summary>Addons</summary>
+
+```js
+/* ember-cli-build.js */
+
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+
+module.exports = function (defaults) {
+  const app = new EmberAddon(defaults, {
+    // Add options here
+    'ember-cli-babel': {
+      enableTypeScriptTransform: true,
+    },
+  });
+
+  return app.toTree();
+};
+```
+
+```js
+/* index.js */
+
+module.exports = {
+  name: require('./package').name,
+
+  options: {
+    'ember-cli-babel': {
+      enableTypeScriptTransform: true,
+    },
+  },
+};
+```
+
+</details>
+
+
+<details>
+<summary>Engines</summary>
+
+```js
+/* ember-cli-build.js */
+
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+
+module.exports = function (defaults) {
+  const app = new EmberAddon(defaults, {
+    // Add options here
+    'ember-cli-babel': {
+      enableTypeScriptTransform: true,
+    },
+  });
+
+  return app.toTree();
+};
+```
+
+```js
+/* index.js */
+
+const EngineAddon = require('ember-engines/lib/engine-addon');
+
+module.exports = EngineAddon.extend({
+  name: require('./package').name,
+
+  'ember-cli-babel': {
+    enableTypeScriptTransform: true,
+  },
+});
+```
+
+</details>
+
+
+NOTE: Setting `enableTypeScriptTransform` to `true` does *not* enable
+type-checking. For integrated type-checking, you will need
+[`ember-cli-typescript`](https://ember-cli-typescript.com).
+
+NOTE: Setting `enableTypeScriptTransform` to `true` is not compatible with
+`ember-cli-typescript < 4.0` because of conflicting Babel plugin ordering
+constraints. It is also unnecessary because `ember-cli-typescript < 4.0`
+adds the TypeScript-Babel transform.
+
 ### Babel config usage
 
 If you want to use the existing babel config from your project instead of the auto-generated one from this addon, then you would need to *opt-in* by passing the config `useBabelConfig: true` as a child property of `ember-cli-babel` in your `ember-cli-build.js` file.

--- a/README.md
+++ b/README.md
@@ -333,9 +333,9 @@ module.exports = function (defaults) {
 ```js
 /* index.js */
 
-const EngineAddon = require('ember-engines/lib/engine-addon');
+const { buildEngine } = require('ember-engines/lib/engine-addon');
 
-module.exports = EngineAddon.extend({
+module.exports = buildEngine({
   name: require('./package').name,
 
   'ember-cli-babel': {


### PR DESCRIPTION
## Description

Currently, the `README` explains how to set `enableTypeScriptTransform` for Ember apps only.

It wasn't clear to me what to do for Ember addons and engines (to be precise, [engines created as an addon](https://ember-engines.com/docs/quickstart#create-as-addon)). The setup for engines turned out to be tricky, because I wasn't supposed to embed the `'ember-cli-babel'` key inside of an `options` hash (the pattern suggested by apps and addons).

I'd like to update the section `Enabling TypeScript Transpilation` so that:

- A developer can copy-paste the code example.
- The code examples closely match the latest Ember blueprint (`v4.9.0-beta.0` at the time of writing). (Note, I continued to write `return app.toTree();`. That is, to limit the scope of this pull request, I didn't assume that the developer uses, or will use, Embroider.)
- The surrounding texts have shorter sentences and are easier to understand. (The change may help those whose native language is not English.)