### PR TITLE
Allow passing in generatorOpts

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,7 @@ module.exports = {
     let providedAnnotation;
     let throwUnlessParallelizable;
     let sourceMaps = false;
+    let generatorOpts = {};
     let shouldCompileModules = _shouldCompileModules(config, this.project);
 
     if (emberCLIBabelConfig) {
@@ -124,9 +125,14 @@ module.exports = {
       sourceMaps = config.babel.sourceMaps;
     }
 
+    if (config.babel && "generatorOpts" in config.babel) {
+      generatorOpts = config.babel.generatorOpts;
+    }
+
     let options = {
       annotation: providedAnnotation || `Babel: ${_parentName(this.parent)}`,
       sourceMaps,
+      generatorOpts,
       throwUnlessParallelizable,
       filterExtensions: this.getSupportedExtensions(config),
       plugins: [],

--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -23,6 +23,7 @@ function _getPresetEnv(config, project) {
   // delete any properties added to `options.babel` that
   // are invalid for @babel/preset-env
   delete presetOptions.sourceMaps;
+  delete presetOptions.generatorOpts;
   delete presetOptions.plugins;
   delete presetOptions.postTransformPlugins;
 


### PR DESCRIPTION
Allows passing in `generatorOpts` to babel  https://babeljs.io/docs/en/options#generatoropts without passing it to preset-env. This will allow passing options like `compact` etc to babel.
Did this as referenced in https://github.com/ef4/ember-auto-import/issues/549#issuecomment-1330104695