### PR TITLE
Remove `babel6` key in test

### DIFF
--- a/node-tests/addon-test.js
+++ b/node-tests/addon-test.js
@@ -1753,7 +1753,7 @@ describe('ember-cli-babel', function() {
       this.addon.parent = Object.assign({}, this.addon.parent, {
         dependencies() { return {}; },
         options: {
-          babel6: {
+          babel: {
             plugins: [ {} ]
           },
         },


### PR DESCRIPTION
Was a bit confusing to see this one. Uncovered when doing https://github.com/mainmatter/ember-test-selectors/pull/1212.