### PR TITLE
Support static class blocks when _not_ using an explicit babel config file.

### DIFF
--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -316,7 +316,7 @@ function _addDecoratorPlugins(plugins, options, config, parent, project) {
       project.ui.writeWarnLine(
         `${_parentName(
           parent
-        )} has added the static class block plugin to its build, but ember-cli-babel provides these by default now! You can remove the transforms, or the addon that provided them, such as @ember-decorators/babel-transforms. Ember supports the stage 1 decorator spec and transforms, so if you were using stage 2, you'll need to ensure that your decorators are compatible, or convert them to stage 1.`
+        )} has added the static class block plugin to its build, but ember-cli-babel provides these by default now! You can remove the transforms, or the addon that provided them.`
       );
     }
   } else {

--- a/lib/babel-options-util.js
+++ b/lib/babel-options-util.js
@@ -311,6 +311,29 @@ function _buildClassFeaturePluginConstraints(constraints, config, parent, projec
 function _addDecoratorPlugins(plugins, options, config, parent, project) {
   const { hasPlugin, addPlugin } = require("ember-cli-babel-plugin-helpers");
 
+  if (hasPlugin(plugins, "@babel/plugin-transform-class-static-block")) {
+    if (parent === project) {
+      project.ui.writeWarnLine(
+        `${_parentName(
+          parent
+        )} has added the static class block plugin to its build, but ember-cli-babel provides these by default now! You can remove the transforms, or the addon that provided them, such as @ember-decorators/babel-transforms. Ember supports the stage 1 decorator spec and transforms, so if you were using stage 2, you'll need to ensure that your decorators are compatible, or convert them to stage 1.`
+      );
+    }
+  } else {
+    addPlugin(
+      plugins,
+      [require.resolve("@babel/plugin-transform-class-static-block"), { legacy: true }],
+      _buildClassFeaturePluginConstraints(
+        {
+          before: ["@babel/plugin-proposal-decorators"],
+        },
+        config,
+        parent,
+        project
+      )
+    );
+  }
+
   if (hasPlugin(plugins, "@babel/plugin-proposal-decorators")) {
     if (parent === project) {
       project.ui.writeWarnLine(

--- a/node-tests/get-babel-options-test.js
+++ b/node-tests/get-babel-options-test.js
@@ -71,7 +71,7 @@ describe("get-babel-options", function () {
       expect(
         _addDecoratorPlugins([], {}, {}, this.addon.parent, this.addon.project)
           .length
-      ).to.equal(4, "plugins added correctly");
+      ).to.equal(5, "plugins added correctly");
     });
 
     it("should include only fields if it detects decorators plugin", function () {
@@ -91,7 +91,7 @@ describe("get-babel-options", function () {
           this.addon.parent,
           this.addon.project
         ).length
-      ).to.equal(4, "plugins were not added");
+      ).to.equal(5, "plugins were not added");
     });
 
     it("should include only decorators if it detects class fields plugin", function () {
@@ -111,7 +111,7 @@ describe("get-babel-options", function () {
           this.addon.parent,
           this.addon.project
         ).length
-      ).to.equal(2, "plugins were not added");
+      ).to.equal(3, "plugins were not added");
     });
 
     it("should use babel options loose mode for class properties", function () {
@@ -157,7 +157,7 @@ describe("get-babel-options", function () {
         "@babel/plugin-transform-typescript",
         "typescript still first"
       );
-      expect(plugins.length).to.equal(5, "class fields and decorators added");
+      expect(plugins.length).to.equal(6, "class fields and decorators added");
     });
 
     it("should include class fields and decorators before typescript if not handling typescript", function () {

--- a/node-tests/get-babel-options-test.js
+++ b/node-tests/get-babel-options-test.js
@@ -172,7 +172,7 @@ describe("get-babel-options", function () {
         this.addon.project
       );
 
-      expect(plugins.length).to.equal(5, "class fields and decorators added");
+      expect(plugins.length).to.equal(6, "class fields and decorators added");
       expect(plugins[4]).to.equal(
         "@babel/plugin-transform-typescript",
         "typescript is now last"

--- a/node-tests/get-babel-options-test.js
+++ b/node-tests/get-babel-options-test.js
@@ -173,7 +173,7 @@ describe("get-babel-options", function () {
       );
 
       expect(plugins.length).to.equal(6, "class fields and decorators added");
-      expect(plugins[4]).to.equal(
+      expect(plugins[5]).to.equal(
         "@babel/plugin-transform-typescript",
         "typescript is now last"
       );


### PR DESCRIPTION
In https://github.com/babel/ember-cli-babel/pull/502
Support for static blocks was added only when using an explicit babel config.

This PR adds the implicit / default support that most folks would use in today's ember apps.

I had missed this because I didn't, at the time, know that the paths for generating which babel plugins we need between the two setups (with and without a babel config) use separate code.

Unblocks: https://github.com/ember-template-imports/ember-template-imports/pull/187