### PR TITLE
doing what babel-plugin-module-resolver would do

### DIFF
--- a/lib/relative-module-paths.js
+++ b/lib/relative-module-paths.js
@@ -3,6 +3,11 @@
 const path = require('path');
 const ensurePosix = require('ensure-posix-path');
 const { moduleResolve } = require('amd-name-resolver');
+const { replaceExtension } = require('babel-plugin-module-resolver/lib/utils');
+
+// From default
+// https://npmx.dev/package-code/babel-plugin-module-resolver/v/5.0.2/lib/normalizeOptions.js
+const stripExtensions = ['.js', '.jsx', '.es', '.es6', '.mjs'];
 
 const BASE_DIR = path.resolve(`${__dirname}/..`);
 
@@ -31,7 +36,7 @@ function resolveRelativeModulePath(name, child) {
 
   // AMD / loader.js does not support extensions
   // (the result of this goes right into AMD's define(here, [....]))
-  return resolved.replace(/\.js$/, '');
+  return replaceExtension(resolved, { stripExtensions });
 }
 
 module.exports = {

--- a/lib/relative-module-paths.js
+++ b/lib/relative-module-paths.js
@@ -36,7 +36,7 @@ function resolveRelativeModulePath(name, child) {
 
   // AMD / loader.js does not support extensions
   // (the result of this goes right into AMD's define(here, [....]))
-  return replaceExtension(resolved, { stripExtensions });
+  return ensurePosix(replaceExtension(resolved, { stripExtensions }));
 }
 
 module.exports = {


### PR DESCRIPTION
Extra code for removing `.js` from file paths so that AMD / loader.js works

In support or defense of https://github.com/emberjs/ember-cli-babel/pull/530